### PR TITLE
✨ (syllabus-single.html): expand learning resources section by default

### DIFF
--- a/site/layouts/partials/course-parts/syllabus-single.html
+++ b/site/layouts/partials/course-parts/syllabus-single.html
@@ -47,7 +47,7 @@
                       <i class="fa fa-chevron-down rotate-icon"></i>
                     </h4>
                   </button>
-                  <div id="learningResources-{{ $index }}" class="collapse">
+                  <div id="learningResources-{{ $index }}" class="collapse show">
                     <ul class="list-group list-group-flush">
                       {{ range sort .learningResources "weight" }}
                         {{ if not .draft }}


### PR DESCRIPTION
The learning resources section is now expanded by default to improve user experience. This change allows users to immediately view the resources without needing to click to expand, making the information more accessible and reducing the number of interactions required to access important content.