### PR TITLE
Emergancy release

### DIFF
--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -18,6 +18,12 @@
       </section>
     {{- end }}
 
+    {{- if not .IsHome }}
+      <section class="container my-5">
+        {{- partial "trustpilot/scrumorg-trustpilot-carousel.html" . }}
+      </section>
+    {{- end }}
+
     {{- block "main" . }}
       <section class="container my-2">
         {{- partial "page-sections/sections.html" . }}
@@ -30,10 +36,6 @@
       <section class="container my-2 siteSectionCallback"></section>
     {{- end }}
 
-
-    <section class="container my-2">
-      {{- partial "trustpilot/scrumorg-trustpilot.html" . }}
-    </section>
     {{- if not .IsHome }}
       {{- partial "our-customers.html" . }}
     {{- end }}

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -34,6 +34,11 @@
         </div>
       </div>
     </div>
+  </section>
+  <section class="container my-5">
+    {{- partial "trustpilot/scrumorg-trustpilot-carousel.html" . }}
+  </section>
+  <section class="container my-5">
     {{- partial "headline.html" . }}
   </section>
 {{- end }}

--- a/site/layouts/partials/page-sections/sections-cards.html
+++ b/site/layouts/partials/page-sections/sections-cards.html
@@ -2,7 +2,6 @@
 <!-- Courses specific rendering -->
 <div class="row">
   {{- if and (not (eq .context.cards nil)) (gt (len .context.cards) 0) }}
-
     {{- $count := len .context.cards }}
     {{- $colClass := "col-xl-4" }}
     {{- if eq (mod $count 3) 0 }}

--- a/site/layouts/partials/trustpilot/scrumorg-trustpilot-carousel.html
+++ b/site/layouts/partials/trustpilot/scrumorg-trustpilot-carousel.html
@@ -1,0 +1,14 @@
+<!-- TrustBox widget - Slider -->
+<div
+  class="trustpilot-widget"
+  data-locale="en-US"
+  data-template-id="54ad5defc6454f065c28af8b"
+  data-businessunit-id="5c12d8d7393a0100015d1c3e"
+  data-style-height="240px"
+  data-style-width="100%"
+  data-theme="light"
+  data-tags="trainer:Nml4dDMzbkNoYXJhY3Ryekr3AA=="
+  data-stars="4,5">
+  <a href="https://www.trustpilot.com/review/scrum.org" target="_blank" rel="noopener">Trustpilot</a>
+</div>
+<!-- End TrustBox widget -->


### PR DESCRIPTION
✨ (layouts): integrate Trustpilot carousel for enhanced user engagement

Introduce a new Trustpilot carousel widget to the site layout to improve user engagement and provide social proof. The carousel is added to the base layout for all pages except the homepage, and directly to the index.html for the homepage. This change replaces the static Trustpilot section with a dynamic carousel, offering a more interactive and visually appealing experience. The new partial
'scrumorg-trustpilot-carousel.html' is created to encapsulate the carousel widget, ensuring modularity and reusability across the site.