### PR TITLE
🔧 (workflow): change runner from windows-latest to ubuntu-latest in s…

### DIFF
--- a/.github/workflows/shedule.yml
+++ b/.github/workflows/shedule.yml
@@ -38,11 +38,12 @@ jobs:
           # GitHub CLI api
           # https://cli.github.com/manual/gh_api
 
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/actions/workflows/main.yaml/dispatches \
-            -f "ref=$latestTag"
+          # GitHub CLI API call
+          gh api `
+          --method POST `
+          -H "Accept: application/vnd.github+json" `
+          -H "X-GitHub-Api-Version: 2022-11-28" `
+          "/repos/${{ github.repository }}/actions/workflows/main.yaml/dispatches" `
+          -f ref=$latestTag
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/shedule.yml
+++ b/.github/workflows/shedule.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: actions/create-github-app-token@v1
         id: app-token

--- a/.github/workflows/shedule.yml
+++ b/.github/workflows/shedule.yml
@@ -26,15 +26,21 @@ jobs:
         run: |
           $tags = git tag --sort=-v:refname | Where-Object { $_ -match '^v[0-9]+\.[0-9]+\.[0-9]+$' }
           $latestTag = $tags | Select-Object -First 1
+
+          if (-not $latestTag) {
+            Write-Host "No valid semantic version tags found. Exiting."
+            exit 0
+          }
+
           echo "latest_tag=$latestTag" | Out-File -FilePath $env:GITHUB_ENV -Append
           Write-Host "Latest tag is $latestTag"
 
-      - uses: convictional/trigger-workflow-and-wait@v1.6.1
-        with:
-          owner: nkdagility
-          repo: nkdagility.com
-          github_token: ${{ steps.app-token.outputs.token }}
-          workflow_file_name: main.yaml
-          ref: ${{ steps.find_tag.outputs.latest_tag }}
-          trigger_workflow: true
-          wait_workflow: false
+          # GitHub CLI api
+          # https://cli.github.com/manual/gh_api
+
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/actions/workflows/main.yaml/dispatches \
+            -f "ref=$latestTag"

--- a/.github/workflows/shedule.yml
+++ b/.github/workflows/shedule.yml
@@ -31,7 +31,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.repository }}
           github_token: ${{ steps.app-token.outputs.token }}
-          workflow_file_name: main.yml
+          workflow_file_name: main.yaml
           ref: ${{ steps.find_tag.outputs.latest_tag }}
           trigger_workflow: true
           wait_workflow: false

--- a/.github/workflows/shedule.yml
+++ b/.github/workflows/shedule.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   find-latest-tag:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/shedule.yml
+++ b/.github/workflows/shedule.yml
@@ -25,6 +25,7 @@ jobs:
           $tags = git tag --sort=-v:refname | Where-Object { $_ -match '^v[0-9]+\.[0-9]+\.[0-9]+$' }
           $latestTag = $tags | Select-Object -First 1
           echo "latest_tag=$latestTag" | Out-File -FilePath $env:GITHUB_ENV -Append
+          Write-Host "Latest tag is $latestTag"
 
       - uses: convictional/trigger-workflow-and-wait@v1.6.1
         with:

--- a/.github/workflows/shedule.yml
+++ b/.github/workflows/shedule.yml
@@ -44,3 +44,5 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/actions/workflows/main.yaml/dispatches \
             -f "ref=$latestTag"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/shedule.yml
+++ b/.github/workflows/shedule.yml
@@ -24,6 +24,11 @@ jobs:
           app-id: ${{ secrets.NKDAGILITY_BOT_APP_ID }}
           private-key: ${{ secrets.NKDAGILITY_BOT_CLIENTSECRET }}
 
+      - name: Authenticate GitHub CLI
+        run: gh auth status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Find latest semantic version tag (PowerShell)
         id: find_tag
         shell: pwsh
@@ -50,4 +55,4 @@ jobs:
           "/repos/${{ github.repository }}/actions/workflows/main.yaml/dispatches" `
           -f ref=$latestTag
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/shedule.yml
+++ b/.github/workflows/shedule.yml
@@ -29,8 +29,8 @@ jobs:
 
       - uses: convictional/trigger-workflow-and-wait@v1.6.1
         with:
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.repository }}
+          owner: nkdagility
+          repo: nkdagility.com
           github_token: ${{ steps.app-token.outputs.token }}
           workflow_file_name: main.yaml
           ref: ${{ steps.find_tag.outputs.latest_tag }}

--- a/.github/workflows/shedule.yml
+++ b/.github/workflows/shedule.yml
@@ -1,5 +1,9 @@
 name: Schedule Re-Deploy Latest
 
+permissions:
+  contents: write
+  actions: write
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
…chedule.yml

Switching the GitHub Actions runner from `windows-latest` to `ubuntu-latest` is done to improve build speed and compatibility. Ubuntu runners are generally faster and more commonly used, which can lead to quicker execution times and fewer compatibility issues with tools and scripts that are often developed with Unix-like environments in mind.