### PR TITLE
🔧 (schedule.yml): update cron schedule to run every 3 hours

### DIFF
--- a/.github/workflows/shedule.yml
+++ b/.github/workflows/shedule.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *" # Adjust the schedule as needed
+    - cron: 0 */3 * * * # Adjust the schedule as needed
 
 jobs:
   find-latest-tag:


### PR DESCRIPTION
The cron schedule in the GitHub Actions workflow is updated to run every 3 hours instead of once daily. This change allows for more frequent execution of the workflow, which can be beneficial for tasks that require regular updates or checks throughout the day.