### PR TITLE
✨ (craft.html, resources-card.html): add draft, scheduled, and expiry indicators for publications

### DIFF
--- a/site/layouts/partials/publications/craft.html
+++ b/site/layouts/partials/publications/craft.html
@@ -5,7 +5,7 @@
       <span class="badge text-bg-secondary">{{- . }}</span>
     {{ end }}
   </div>
-  <div class="text-muted" title="Published on {{ .Date.Format "2 January 2006" }} and last modified on {{ .GitInfo.AuthorDate.Format "2 January 2006" }} and expires on {{ .ExpiryDate "2 January 2006" }} ">
+  <div class="text-muted" title="Published on {{ .Date.Format "2 January 2006" }} and last modified on {{ .Lastmod.Format "2 January 2006" }} and expires on {{ .ExpiryDate.Format "2 January 2006" }} ">
     {{ if .Draft }}
       <span class="badge text-bg-warning">Draft</span>
     {{ else if gt .Date (now) }}

--- a/site/layouts/partials/publications/craft.html
+++ b/site/layouts/partials/publications/craft.html
@@ -5,7 +5,7 @@
       <span class="badge text-bg-secondary">{{- . }}</span>
     {{ end }}
   </div>
-  <div class="text-muted" title="Published on {{ .Date.Format "2 January 2006" }} and last modified on {{ .Lastmod.Format "2 January 2006" }} and expires on {{ .ExpiryDate.Format "2 January 2006" }} ">
+  <div class="text-muted" title="Published on {{ .Date.Format "2 January 2006" }} and last modified on {{ .Lastmod.Format "2 January 2006" }}{{ if .ExpiryDate }}and expires on {{ .ExpiryDate.Format "2 January 2006" }}{{ end }}">
     {{ if .Draft }}
       <span class="badge text-bg-warning">Draft</span>
     {{ else if gt .Date (now) }}

--- a/site/layouts/partials/publications/craft.html
+++ b/site/layouts/partials/publications/craft.html
@@ -5,8 +5,17 @@
       <span class="badge text-bg-secondary">{{- . }}</span>
     {{ end }}
   </div>
-  <div class="text-muted" title="Published on {{ .Date.Format "2 January 2006" }} and last modified on {{ .GitInfo.AuthorDate.Format "2 January 2006" }}">
-    Published <a href="{{- .Permalink }}" rel="bookmark"><time class="entry-date published updated" datetime="{{- .Date }}">{{- .Date.Format "2 January 2006" }}</time></a>
+  <div class="text-muted" title="Published on {{ .Date.Format "2 January 2006" }} and last modified on {{ .GitInfo.AuthorDate.Format "2 January 2006" }} and expires on {{ .ExpiryDate "2 January 2006" }} ">
+    {{ if .Draft }}
+      <span class="badge text-bg-warning">Draft</span>
+    {{ else if gt .Date (now) }}
+      <span class="badge text-bg-danger">Scheduled</span> for <a href="{{- .Permalink }}" rel="bookmark"><time class="entry-date published updated" datetime="{{- .Date }}">{{- .Date.Format "2 January 2006" }}</time></a>
+    {{ else }}
+      Published on <a href="{{- .Permalink }}" rel="bookmark"><time class="entry-date published updated" datetime="{{- .Date }}">{{- .Date.Format "2 January 2006" }}</time></a>
+    {{ end }}
+    {{- if gt .ExpiryDate (now) }}
+      and expires on <time datetime="{{- .ExpiryDate }}">{{- .ExpiryDate.Format "2 January 2006" }}</time>
+    {{- end }}
   </div>
   <div class="text-muted">
     <div class="text-muted">{{- partial "resources/contributors.html" . }}</div>

--- a/site/layouts/partials/resources-card.html
+++ b/site/layouts/partials/resources-card.html
@@ -23,5 +23,14 @@
   </div>
   <div class="card-footer border-transparent bg-white p-1 text-start">
     <a href="{{- .Permalink }}" class="btn btn-primary btn-sm" title="More information on {{- .Title }}">Read <i class="fa-solid fa-arrow-right"></i></a>
+    {{ if .Draft }}
+      <span class="badge text-bg-warning">Draft</span>
+    {{ end }}
+    {{ if gt .Date (now) }}
+      <span class="badge text-bg-danger" title="Scheduled for {{- .Date.Format "2 January 2006" }}">Scheduled</span>
+    {{ end }}
+    {{- if gt .ExpiryDate (now) }}
+      <span class="badge text-bg-danger" title="Expires on {{- .ExpiryDate.Format "2 January 2006" }}">Expires</span>
+    {{- end }}
   </div>
 </div>


### PR DESCRIPTION

Enhance the user interface by displaying badges for draft, scheduled, and expired publications. This provides users with clear visual cues about the status of each publication. Drafts are marked with a warning badge, scheduled publications with a danger badge, and expiry dates are shown if applicable. This improves content management and user awareness of publication timelines.