### PR TITLE
📝 (lean-agile-consultancy): add new alias for agile consultancy page

### DIFF
--- a/site/content/capabilities/lean-agile-consultancy/index.md
+++ b/site/content/capabilities/lean-agile-consultancy/index.md
@@ -15,6 +15,7 @@ slug: lean-agile-consultancy
 aliases:
   - /capabilities/lean-agile-consultancy/
   - /agile-consulting-coaching
+  - /agile-consultancy/
 card:
   button:
     content: Transform Your Organization


### PR DESCRIPTION
Add a new alias `/agile-consultancy/` to the lean-agile consultancy page to improve accessibility and ensure users can reach the page using different common URL paths. This change enhances user experience by providing more intuitive and memorable links.