### PR TITLE
✨ (breadcrumbs.html): add copy path button for non-production environ…

### DIFF
--- a/site/layouts/partials/infrastructure/breadcrumbs.html
+++ b/site/layouts/partials/infrastructure/breadcrumbs.html
@@ -31,6 +31,11 @@
     {{- end }}
   </ul>
 </nav>
+{{- if ne hugo.Environment "production" }}
+  <button class="btn btn-outline-info" title="Click to copy" onclick="navigator.clipboard.writeText('{{ .Path }}');" style="--bs-btn-padding-y: .25rem; --bs-btn-padding-x: .5rem; --bs-btn-font-size: .75rem;">{{ .Path }} <i class="fa-regular fa-clipboard"></i></button>
+{{ end }}
+
+
 <style>
   .breadcrumb {
     list-style: none;

--- a/site/layouts/resources/single.html
+++ b/site/layouts/resources/single.html
@@ -2,7 +2,7 @@
   <section class="container my-2" style="max-width: 700px !important">
     <div class="row p-2">
       <div class="col-12">
-        <h1 class="mb-4 nkda-heading-primary">{{- .Title | markdownify }}{{- if ne hugo.Environment "production" }}- {{ if .Params.videoId }}({{ .Params.videoId }}){{ end }}{{ end }}</h1>
+        <h1 class="mb-4 nkda-heading-primary">{{- .Title | markdownify }}</h1>
         {{- if .Params.subtitle }}
           <h2 class="mb-4 nkda-heading-secondary">{{- .Params.subtitle | markdownify }}</h2>
         {{- end }}


### PR DESCRIPTION
…ments

♻️ (single.html): remove videoId display from title in non-production environments

Introduce a new feature in the breadcrumbs partial to allow users to copy the current path to the clipboard with a button, enhancing developer experience in non-production environments. The button is hidden in production to maintain a clean UI. Additionally, refactor the single resource template by removing the videoId from the title in non-production environments, simplifying the display and focusing on the main content.