### PR TITLE
✨ (youtube.html): enhance YouTube shortcode to support video metadata…

### DIFF
--- a/site/layouts/shortcodes/youtube.html
+++ b/site/layouts/shortcodes/youtube.html
@@ -1,4 +1,11 @@
 <div class="embed video-player">
   <iframe class="youtube-player" type="text/html" width="640" height="385" src="https://www.youtube.com/embed/{{ index .Params 0 }}" allowfullscreen frameborder="0"> </iframe>
 </div>
-{{- partial "jsonld/youtube.html" . }}
+{{- $videoPath := (print "/resources/videos/youtube/" (index .Params 0)) }}
+{{- if .Page.Params.videoId -}}
+  {{- partial "jsonld/youtube.html" . -}}
+{{- else }}
+  {{- with .Site.GetPage (print "/resources/videos/youtube/" (index .Params 0)) -}}
+    {{- partial "jsonld/youtube.html" . }}
+  {{- end -}}
+{{- end -}}


### PR DESCRIPTION
… retrieval

The YouTube shortcode is updated to conditionally retrieve video metadata. If a videoId is present in the page parameters, it uses that to render the JSON-LD partial. Otherwise, it attempts to fetch the video metadata from a predefined path within the site structure. This change allows for more flexible and dynamic handling of video metadata, improving the site's capability to manage video content efficiently.