### PR TITLE
🔧 (shedule.yml): update workflow to use GitHub API for latest release…

### DIFF
--- a/.github/workflows/shedule.yml
+++ b/.github/workflows/shedule.yml
@@ -33,16 +33,20 @@ jobs:
         id: find_tag
         shell: pwsh
         run: |
-          $tags = git tag --sort=-v:refname | Where-Object { $_ -match '^v[0-9]+\.[0-9]+\.[0-9]+$' }
-          $latestTag = $tags | Select-Object -First 1
+          # GitHub API URL for the latest release
+          $apiUrl = "https://api.github.com/repos/${{ github.repository }}/releases/latest"
 
-          if (-not $latestTag) {
-            Write-Host "No valid semantic version tags found. Exiting."
-            exit 0
-          }
+          # Send the API request
+          $response = Invoke-RestMethod -Uri $apiUrl -Headers @{ "Accept" = "application/vnd.github+json" }
 
-          echo "latest_tag=$latestTag" | Out-File -FilePath $env:GITHUB_ENV -Append
-          Write-Host "Latest tag is $latestTag"
+          # Extract release information
+          $latestRelease = $response | Select-Object -Property tag_name, name, published_at, body
+
+          # Output the details
+          Write-Host "Latest Release for ${{ github.repository }}:"
+          Write-Host "Tag: $($latestRelease.tag_name)"
+          Write-Host "Name: $($latestRelease.name)"
+          Write-Host "Published: $($latestRelease.published_at)"
 
           # GitHub CLI api
           # https://cli.github.com/manual/gh_api
@@ -53,6 +57,6 @@ jobs:
           -H "Accept: application/vnd.github+json" `
           -H "X-GitHub-Api-Version: 2022-11-28" `
           "/repos/${{ github.repository }}/actions/workflows/main.yaml/dispatches" `
-          -f ref=$latestTag
+          -f ref=$($latestRelease.tag_name)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
… info

The workflow now uses the GitHub API to fetch the latest release information instead of relying on local git tags. This change ensures that the workflow retrieves the most recent release data directly from the GitHub repository, which is more reliable and accurate. It also provides additional release details such as the release name and publication date, enhancing the workflow's functionality.