### PR TITLE
✨ (head.html): add conditional backlink meta tag for video pages

### DIFF
--- a/site/layouts/partials/infrastructure/head.html
+++ b/site/layouts/partials/infrastructure/head.html
@@ -6,9 +6,13 @@
 
 {{- partial "infrastructure/seo.html" . }}
 
-
-<meta name="giscus:backlink" content="https://nkdagility.com{{- .RelPermalink }}" />
+{{ if .Params.videoId }}
+  <meta name="giscus:backlink" content="https://nkdagility.com/resources/videos/{{- .Params.videoId }}" />
+{{ else }}
+  <meta name="giscus:backlink" content="https://nkdagility.com{{- .RelPermalink }}" />
+{{ end }}
 <meta name="giscus:description" content="{{- .Summary | plainify }}" />
+
 <link rel="icon" href="{{- "favicon.ico" | relURL }}" type="image/x-icon" /> <meta name="copyright" content="{{- printf "© 2013-%s Naked Agility Limited. All rights reserved." (now.Format "2006") }}" />
 <meta
   name="license"


### PR DESCRIPTION
Introduce a conditional check for the `videoId` parameter to customize the `giscus:backlink` meta tag. This change ensures that when a page has a `videoId`, the backlink points to the specific video resource URL, enhancing SEO and user navigation. If no `videoId` is present, the backlink defaults to the page's relative permalink.