### PR TITLE
Invalid URL in field 'sameAs' (in 'mainEntity')

### DIFF
--- a/site/layouts/partials/infrastructure/seo.html
+++ b/site/layouts/partials/infrastructure/seo.html
@@ -133,13 +133,13 @@
           {{- end }}
           "description": {{(.Description | default .Params.card.content) | plainify }},
           "sameAs": [
-            {{- $additional := slice .Permalink -}}
-            {{- $socialProfiles := .Params.socialProfiles -}}
-            {{- $allProfiles := $additional | append $socialProfiles -}}
-            {{- range $index, $profile := $allProfiles -}}
-              {{- if $index }}, {{ end }}{{ printf "%s" $profile }}
-            {{- end -}}
-            ]
+              {{- $additional := slice .Permalink -}}
+              {{- $socialProfiles := .Params.socialProfiles | default (slice) -}}
+              {{- $allProfiles := $additional | append $socialProfiles -}}
+              {{- range $index, $profile := $allProfiles -}}
+                  {{- if $index }}, {{ end }}{{ $profile }}
+              {{- end -}}
+          ]
         }
       },
       {{ else }}


### PR DESCRIPTION
🐛 (seo.html): fix potential nil pointer issue with socialProfiles 

Ensure that the `socialProfiles` parameter defaults to an empty slice if not provided. This prevents potential nil pointer errors when appending to the `allProfiles` slice. The change enhances the robustness of the SEO template by ensuring that the `sameAs` field always processes a valid list of profiles, even if none are specified in the parameters.