### PR TITLE
🔧 (update-youtube.yml): add GOOGLE_REFRESH_TOKEN to environment variables

### DIFF
--- a/.github/workflows/update-youtube.yml
+++ b/.github/workflows/update-youtube.yml
@@ -30,6 +30,7 @@ jobs:
         env:
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
           GOOGLE_ACCESS_TOKEN: ${{ secrets.GOOGLE_ACCESS_TOKEN }}
+          GOOGLE_REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}
 
       - name: Update-YoutubeMarkdownFiles
         shell: pwsh

--- a/.github/workflows/update-youtube.yml
+++ b/.github/workflows/update-youtube.yml
@@ -31,6 +31,8 @@ jobs:
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
           GOOGLE_ACCESS_TOKEN: ${{ secrets.GOOGLE_ACCESS_TOKEN }}
           GOOGLE_REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}
+          GOOGLE_CLINET_ID: ${{ secrets.GOOGLE_CLINET_ID }}
+          GOOGLE_CLINET_SECRET: ${{ secrets.GOOGLE_CLINET_SECRET }}
 
       - name: Update-YoutubeMarkdownFiles
         shell: pwsh


### PR DESCRIPTION


Adding the GOOGLE_REFRESH_TOKEN to the environment variables ensures that the workflow can refresh the Google access token when it expires. This change enhances the reliability and continuity of the workflow by preventing interruptions due to token expiration.