### PR TITLE
Fix for Breva's silly documentation

### DIFF
--- a/site/layouts/partials/infrastructure/footer.html
+++ b/site/layouts/partials/infrastructure/footer.html
@@ -178,8 +178,6 @@
       equeue: [],
       client_key: "xobflbrha14pjdh0uo0lm396",
     };
-    /* OPTIONAL: email for identify request*/
-    window.sib.email_id = "contact@nkdagility.com";
     window.sendinblue = {};
     for (var j = ["track", "identify", "trackLink", "page"], i = 0; i < j.length; i++) {
       (function (k) {


### PR DESCRIPTION
♻️ (footer.html): remove hardcoded email_id from Sendinblue configuration

The hardcoded email_id in the Sendinblue configuration is removed to enhance privacy and security. This change prevents exposing sensitive information in the source code and allows for more flexible configuration management.