### PR TITLE
Replace old Google Tag Manager Code

### DIFF
--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -4,9 +4,26 @@
 {{ end }}
 <html lang="{{- or site.Language.LanguageCode }}" dir="{{- or site.Language.LanguageDirection `ltr` }}">
   <head>
+    <!-- Google Tag Manager -->
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != "dataLayer" ? "&l=" + l : "";
+        j.async = true;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, "script", "dataLayer", "GTM-WRVT65");
+    </script>
+    <!-- End Google Tag Manager -->
     {{- partial "infrastructure/head.html" . }}
   </head>
   <body data-ndka-environment="{{- hugo.Environment }}" data-ndka-version="v#{GitVersion.SemVer}#">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WRVT65" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     {{- partial "infrastructure/header.html" . }}
 
     {{- block "breadcrumbs" . }}

--- a/site/layouts/partials/infrastructure/footer.html
+++ b/site/layouts/partials/infrastructure/footer.html
@@ -171,50 +171,6 @@
     beTracker.t({ hash: "aec7284edc8d1939969ff642d8211446" });
   });
 </script>
-<!-- Brevo  {literal} -->
-<script type="text/javascript" async>
-  (function () {
-    window.sib = {
-      equeue: [],
-      client_key: "xobflbrha14pjdh0uo0lm396",
-    };
-    window.sendinblue = {};
-    for (var j = ["track", "identify", "trackLink", "page"], i = 0; i < j.length; i++) {
-      (function (k) {
-        window.sendinblue[k] = function () {
-          var arg = Array.prototype.slice.call(arguments);
-          (
-            window.sib[k] ||
-            function () {
-              var t = {};
-              t[k] = arg;
-              window.sib.equeue.push(t);
-            }
-          )(arg[0], arg[1], arg[2], arg[3]);
-        };
-      })(j[i]);
-    }
-    var n = document.createElement("script"),
-      i = document.getElementsByTagName("script")[0];
-    (n.type = "text/javascript"), (n.id = "sendinblue-js"), (n.async = !0), (n.src = "https://sibautomation.com/sa.js?key=" + window.sib.client_key), i.parentNode.insertBefore(n, i), window.sendinblue.page();
-  })();
-</script>
-<!-- Brevo Conversations {literal} -->
-<script async>
-  (function (d, w, c) {
-    w.BrevoConversationsID = "671625f4d3c7ed16db0bc208";
-    w[c] =
-      w[c] ||
-      function () {
-        (w[c].q = w[c].q || []).push(arguments);
-      };
-    var s = d.createElement("script");
-    s.async = true;
-    s.src = "https://conversations-widget.brevo.com/brevo-conversations.js";
-    if (d.head) d.head.appendChild(s);
-  })(document, window, "BrevoConversations");
-</script>
-<!-- /Brevo Conversations {/literal} -->
 {{/* <!-- Algolia -->
   <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
   <script type="module">

--- a/site/layouts/partials/infrastructure/head.html
+++ b/site/layouts/partials/infrastructure/head.html
@@ -36,16 +36,6 @@ naked Agility Limited. All content is copyrighted. No reproduction or distributi
 <link async rel="stylesheet" href="{{- "css/cards.css" | relURL }}" />
 <!-- sections -->
 <link async rel="stylesheet" href="{{- "css/sections.css" | relURL }}" />
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-44XG57BE28"></script>
-<script async>
-  window.dataLayer = window.dataLayer || [];
-  function gtag() {
-    dataLayer.push(arguments);
-  }
-  gtag("js", new Date());
-  gtag("config", "G-44XG57BE28");
-</script>
 
 <!-- shopifycdn -->
 {{/* <script src="https://sdks.shopifycdn.com/js-buy-sdk/v2/latest/index.umd.min.js"></script>

--- a/site/layouts/partials/infrastructure/seo.html
+++ b/site/layouts/partials/infrastructure/seo.html
@@ -1,5 +1,5 @@
 <!-- Search Engine Optimisation -->
-<title>{{- .Title }} | {{- .Site.Title }}</title>
+<title>{{- .Title }} | {{ .Site.Title }}</title>
 
 {{- $canonicalUrl := "" -}}
 {{- if .Params.canonicalUrl -}}


### PR DESCRIPTION
✨📝 (baseof.html, footer.html, head.html, seo.html): integrate GoogleTag Manager and remove redundant scripts

Integrate Google Tag Manager (GTM) to enhance tracking and analytics capabilities. GTM provides a more flexible and centralized way to manage tags and scripts. Remove the Brevo and Google Analytics scripts to avoid redundancy and potential conflicts, as GTM can handle these functionalities. Additionally, fix a minor formatting issue in the SEO title tag for consistency.