### PR TITLE
Remove routes file entirely

### DIFF
--- a/site/layouts/partials/infrastructure/publish-redirects.html
+++ b/site/layouts/partials/infrastructure/publish-redirects.html
@@ -8,9 +8,6 @@
     )
   -}}
 {{- end }}
-{{- $routes := dict "routes" ($.Scratch.Get "routes") }}
-{{- $jsonOutput := $routes | jsonify }}
-{{- (resources.FromString "routes.json" $jsonOutput).Publish }}
 {{- range $p := sort site.AllPages "Path" }}
   {{- range $alias := sort $p.Aliases }}
     {{- if not (strings.HasSuffix $alias "/") }}


### PR DESCRIPTION
♻️ (publish-redirects.html): remove unused JSON output generation for routes

The generation of a JSON output for routes was removed as it was not being used in the current implementation. This cleanup helps in reducing unnecessary code and potential confusion, improving the maintainability of the codebase.