### PR TITLE
Fix for duplicate image URL

### DIFF
--- a/.powershell/_includes/ImagesToBlobStorage.ps1
+++ b/.powershell/_includes/ImagesToBlobStorage.ps1
@@ -60,15 +60,23 @@ function Rewrite-ImageLinks {
         # Regex to match all src attributes with image paths
         $ImageRegex = "(?i)(src|content|href)\s*=\s*([""']?)(?<url>[^\s""'>]+\.(jpg|jpeg|png|gif|webp|svg))\2"
 
-        # Find all matches and make them distinct
-        $Matches = [regex]::Matches($FileContent, $ImageRegex) | Select-Object -Unique
+        # Find all matches and ensure uniqueness based on the 'url' group
+        $Matches = [regex]::Matches($FileContent, $ImageRegex)
+        $UniqueUrls = @()
 
         foreach ($Match in $Matches) {
-           
-            $OriginalPath = $Match.Groups['url'].Value
-            $UpdatedPath = $OriginalPath
+            $Url = $Match.Groups['url'].Value
+        
+            # Add the URL to the array if it's not already included
+            if ($Url -notin $UniqueUrls) {
+                $UniqueUrls += $Url
+            }
+        }    
 
+        foreach ($UniqueUrl in $UniqueUrls) {
            
+            $OriginalPath = $UniqueUrl
+            $UpdatedPath = $OriginalPath
 
             # Skip if the path already contains the BlobUrl
             if ($OriginalPath -like "$BlobUrl*") {

--- a/.powershell/dev/Sync-BlobStorageImages.ps1
+++ b/.powershell/dev/Sync-BlobStorageImages.ps1
@@ -5,7 +5,7 @@ Write-Host "Starting process..."
 
 # Variables
 if (-not $env:LOCAL_IMAGE_PATH) {
-    $env:LOCAL_IMAGE_PATH = "C:\Users\MartinHinshelwoodNKD\Downloads\Site (5)\" # Local folder containing images and HTML files
+    $env:LOCAL_IMAGE_PATH = ".\public" # Local folder containing images and HTML files
     
 }
 Write-Host "Local Image Path: $env:LOCAL_IMAGE_PATH"
@@ -16,11 +16,11 @@ Write-Host "Blob URL Bit: $env:BLOB_URL_BIT"
 if (-not $env:BLOB_STORAGE_URL) {
     $env:BLOB_STORAGE_URL = "https://nkdagilityblobs.blob.core.windows.net/`$web"  # Base URL for Blob storage
 }
-Write-Host "Blob Storage URL: $env:BLOB_STORAGE_URL"
-if (-not $env:AZURE_BLOB_STORAGE_SAS_TOKEN) {
-    Write-Host "Azure Blob Storage SAS Token not provided. "
-    exit 2
-}
+# Write-Host "Blob Storage URL: $env:BLOB_STORAGE_URL"
+# if (-not $env:AZURE_BLOB_STORAGE_SAS_TOKEN) {
+#     Write-Host "Azure Blob Storage SAS Token not provided. "
+#     exit 2
+# }
 
 #Upload-ImageFiles -LocalPath $env:LOCAL_IMAGE_PATH -BlobUrlBase $env:BLOB_STORAGE_URL -AzureSASToken $env:AZURE_BLOB_STORAGE_SAS_TOKEN
 


### PR DESCRIPTION
fix(ImagesToBlobStorage.ps1): ensure uniqueness of image URLs by using an array to track already included URLs

chore(Sync-BlobStorageImages.ps1): update local image path to a relative path for better portability and remove commented-out code for clarity