### PR TITLE
Fix for missing PDF

### DIFF
--- a/site/content/company/supplier-bank-account-details/index.md
+++ b/site/content/company/supplier-bank-account-details/index.md
@@ -6,6 +6,9 @@ author: naked Agility Ltd
 description: Details about supplier, corporate registration, banking, and insurance for naked Agility Ltd.
 aliases:
   - /accounts/
+resources:
+  - src: "./pdfs/account_details_proof_aud-20240625.pdf"
+    name: "account_details_proof_aud-20240625.pdf"
 headline:
   cards: []
   title: Supplier & Bank Account Details

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -74,8 +74,7 @@ cascade:
       path: /tags/**
     _build:
       render: never
-  - _build:
-      publishResources: false
+
 
 permalinks:
   taxonomy:


### PR DESCRIPTION
feat(supplier-bank-account-details): add resources section with PDF proof of account details for better documentation

chore(hugo.yaml): remove unnecessary _build configuration to simplify settings