### PR TITLE
Update instructions for categories

### DIFF
--- a/.powershell/_includes/ClassificationHelpers.ps1
+++ b/.powershell/_includes/ClassificationHelpers.ps1
@@ -6,16 +6,18 @@ function Get-CatalogHashtable {
     )
 
     # Get the metadata (assumed to be an array of objects)
-    $catalog = Get-MarkdownMetadata -FolderPath "$FolderPath\$Classification" | ConvertFrom-Json 
+    $catalog = Get-HugoMarkdownList -FolderPath "$FolderPath\$Classification"
 
     # Initialize an empty hashtable
     $catalogHash = @{}
 
     # Loop through each object and store the Title-Description pair in the hashtable
-    foreach ($item in $catalog) {
-        if ($item.Title -and $item.Description) {
-            $catalogHash[$item.Title] = $item.Description
+    foreach ($markdownMeta in $catalog) {
+        $instructions = $markdownMeta.FrontMatter.Instructions
+        if ($instructions -eq $null) {
+            $instructions = $markdownMeta.FrontMatter.Description
         }
+        $catalogHash[$markdownMeta.FrontMatter.Title] = $instructions
     }
 
     return $catalogHash
@@ -59,7 +61,6 @@ function Get-CategoryConfidenceWithChecksum {
             $categoryScores[$category] = $cachedData.$category
             continue
         }
-
         $prompt = @"
 You are an AI expert in content classification. Evaluate how well the given content aligns with the category **"$category"**. With that classification meaning "$($Catalog[$category])"
 

--- a/.powershell/_includes/HugoHelpers.ps1
+++ b/.powershell/_includes/HugoHelpers.ps1
@@ -214,7 +214,7 @@ function Save-HugoMarkdown {
     Set-Content -Path $Path -Value $updatedContent -Encoding UTF8NoBOM -NoNewline
 }
 
-function Get-MarkdownMetadata {
+function Get-HugoMarkdownList {
     param (
         [string]$FolderPath
     )
@@ -225,27 +225,10 @@ function Get-MarkdownMetadata {
     foreach ($markdownFile in $mdFiles) {
         # Load Markdown data using Get-HugoMarkdown
         $hugoMarkdown = Get-HugoMarkdown -Path $markdownFile.FullName
-        
-        # Extract title and description if available
-        $title = $hugoMarkdown.FrontMatter.title
-        $description = $hugoMarkdown.FrontMatter.description
-
-        # Fallback if title or description is missing
-        if (-not $title -or $title -eq '') {
-            $title = "Untitled"
-        }
-        if (-not $description -or $description -eq '') {
-            $description = "No description available"
-        }
-
-        # Create a structured object
-        $metadataList += [PSCustomObject]@{
-            Title       = $title
-            Description = $description
-        }
+        $metadataList += $hugoMarkdown
     }
 
-    return $metadataList | ConvertTo-Json -Depth 1
+    return $metadataList
 }
 
 Write-InfoLog "HugoHelpers.ps1 loaded"

--- a/.powershell/single-use/resources/Update-Catagories.ps1
+++ b/.powershell/single-use/resources/Update-Catagories.ps1
@@ -38,5 +38,5 @@ $resources | ForEach-Object {
     Write-InfoLog "Processing post: $(Resolve-Path -Path $resourceDir -Relative)"
 
     #Remove-ClassificationsFromCache -ClassificationsToRemove @("Technical Excellence") -CacheFolder $resourceDir -ClassificationType "categories"
-    Remove-ClassificationsFromCacheThatLookBroken -ClassificationCatalog $tagsCatalog -CacheFolder $resourceDir -ClassificationType "tags"
+    #Remove-ClassificationsFromCacheThatLookBroken -ClassificationCatalog $tagsCatalog -CacheFolder $resourceDir -ClassificationType "tags"
 }

--- a/site/content/categories/code-and-complexity.md
+++ b/site/content/categories/code-and-complexity.md
@@ -1,4 +1,5 @@
 ---
 title: Code and Complexity
-description: Discussions around software code quality, and best practices in development.
+description: Discussions around software code quality, and best practices in software development.
+Instructions: "Discussions strictly focused on software code quality, best practices in software development, and programming-related challenges. This category is exclusively for technical topics involving coding, software architecture, algorithms, and engineering principles. Non-code-related discussions should be placed in other relevant categories."
 ---


### PR DESCRIPTION
♻️ (ClassificationHelpers.ps1): refactor metadata extraction to use Get-HugoMarkdownList

✨ (code-and-complexity.md): add Instructions field for more detailed guidance
📝 (HugoHelpers.ps1): rename function for clarity and remove JSON conversion

Refactor the metadata extraction process to directly use the Get-HugoMarkdownList function, simplifying the code and removing unnecessary JSON conversion. This change improves the maintainability and readability of the script. The Instructions field is added to code-and-complexity.md to provide more detailed guidance on the category's intended use, ensuring discussions remain focused on technical topics. The function Get-MarkdownMetadata is renamed to Get-HugoMarkdownList for better clarity and alignment with its purpose. Commented out a line in Update-Catagories.ps1 to prevent unintended cache removal during updates.