### PR TITLE
♻️ (layouts): refactor client modal into a partial for reuse

### DIFF
--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -4,6 +4,7 @@
 
 {{- define "headline" }}
   <section class="container my-5">
+    {{- partial "taking-on-new-client.html" . }}
     <div class="row p-2 p-lg-6">
       <div class="col-xl-6 p-lg-3">
         <h1 class="mb-4 nkda-heading-primary">The home of technical leadership and engineering excellence for software development teams.</h1>
@@ -16,9 +17,12 @@
           <div class="col-12">
             <div class="card text-center card-left-border">
               <div class="card-body">
-                <h3 class="card-title">How Usable Working Products Are Your Ultimate Weapon Against Risks</h3>
-                <p class="card-text">The only way to mitigate risk when employing Agile practices is by continuously delivering a usable working product. Agile is not about spinning the hamster wheels but delivering shippable increments that users can interact with.</p>
-                <a href="/resources/blog/how-usable-working-products-are-your-ultimate-weapon-against-risks/" class="btn btn-primary">Read more...</a>
+                {{ range first 1 (where .Site.RegularPages.ByWeight "Params.ResourceType" "blog") }}
+                  <h3 class="card-title">{{ .Title }}</h3>
+                  <p class="card-text">{{ .Description }}</p>
+                  <a href="{{ .RelPermalink }}" class="btn btn-primary">Read more...</a>
+                {{ end }}
+
               </div>
             </div>
           </div>

--- a/site/layouts/partials/infrastructure/breadcrumbs.html
+++ b/site/layouts/partials/infrastructure/breadcrumbs.html
@@ -34,33 +34,9 @@
       </ul>
     </nav>
   </div>
-  {{ if and (.Site.Params.TakingOnNewClients) (ne .RelPermalink "/company/book-online/") }}
-    <div class="col-md-4 text-end">
-      <!-- Link to Open Modal -->
-      <i class="fa-solid fa-rocket-launch"></i> <i class="fa-solid fa-bracket-curly"></i> <a href="#" data-bs-toggle="modal" data-bs-target="#newClientsModal">We're looking for 1 new client!</a> <i class="fa-solid fa-bracket-curly-right"></i>
-
-      <!-- Modal -->
-      <div class="modal fade" id="newClientsModal" tabindex="-1" aria-labelledby="newClientsModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h5 class="modal-title" id="newClientsModalLabel">We're looking for 1 new client!</h5>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body text-start">
-              <p>We operate on a fixed-price model, eliminating the need for time tracking or approval gates. Our engagements are based on a defined time period, ensuring full flexibility to collaborate on any topic within our expertise—technical, process-related, or strategic.</p>
-              <p>Check out what <a href="">Working with Us</a> looks like.</p>
-              <p>To maintain quality and focus, <strong>we limit concurrent engagements</strong> and never overbook. When we work with you, our attention is fully on your needs. Whether you need a short-term boost or a long-term strategic partnership, we tailor our approach to deliver real value.</p>
-              <p><a href="/company/book-online/">Get in touch today</a> to discuss how we can support your organisation’s agility, DevOps adoption, and value delivery.</p>
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  {{ end }}
+  <div class="col-md-4 text-end">
+    {{- partial "taking-on-new-client.html" . }}
+  </div>
 </div>
 
 <style>

--- a/site/layouts/partials/taking-on-new-client.html
+++ b/site/layouts/partials/taking-on-new-client.html
@@ -1,0 +1,25 @@
+{{ if and (.Site.Params.TakingOnNewClients) (ne .RelPermalink "/company/book-online/") }}
+  <!-- Link to Open Modal -->
+  <i class="fa-solid fa-rocket-launch"></i> <i class="fa-solid fa-bracket-curly"></i> <a href="#" data-bs-toggle="modal" data-bs-target="#newClientsModal">We're looking for 1 new client!</a> <i class="fa-solid fa-bracket-curly-right"></i>
+
+  <!-- Modal -->
+  <div class="modal fade" id="newClientsModal" tabindex="-1" aria-labelledby="newClientsModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="newClientsModalLabel">We're looking for 1 new client!</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body text-start">
+          <p>We operate on a fixed-price model, eliminating the need for time tracking or approval gates. Our engagements are based on a defined time period, ensuring full flexibility to collaborate on any topic within our expertise—technical, process-related, or strategic.</p>
+          <p>Check out what <a href="/company/working-with-us/">Working with Us</a> looks like.</p>
+          <p>To maintain quality and focus, <strong>we limit concurrent engagements</strong> and never overbook. When we work with you, our attention is fully on your needs. Whether you need a short-term boost or a long-term strategic partnership, we tailor our approach to deliver real value.</p>
+          <p><a href="/company/book-online/">Get in touch today</a> to discuss how we can support your organisation’s agility, DevOps adoption, and value delivery.</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+{{ end }}


### PR DESCRIPTION
Extract the "taking on new client" modal into a separate partial to improve code reusability and maintainability. This change removes duplicate code from multiple files and centralizes the modal logic, making it easier to update and manage. Additionally, the blog section now dynamically displays the latest blog post, enhancing the site's content freshness and engagement.