### PR TITLE
Private class button to book meeting, and link to "Working with us" on that page

### DIFF
--- a/site/content/company/book-online/index.md
+++ b/site/content/company/book-online/index.md
@@ -16,6 +16,8 @@ headline:
   content: |
     We operate on a fixed-price, timeboxed model, ensuring clarity, focus, and real value without hourly tracking or approval delays. If you're ready to explore how we can help, book an initial consultation to get started.
 
+    [Working with us!]({{< ref "/company/working-with-us" >}})
+
     ### How It Works
 
     1. Book a Call – Select a time that works for you.

--- a/site/layouts/partials/delivery-parts/deliveryfound-summery.html
+++ b/site/layouts/partials/delivery-parts/deliveryfound-summery.html
@@ -52,6 +52,10 @@
               <i class="fas fa-heart position-absolute start-0 top-50 translate-middle-y ms-2"></i>
               Follow
             </a>
+            <a href="/company/book-online/" class="btn btn-nkdagility-primary w-100 position-relative" title="Talk to us for private or corporate sessions">
+              <i class="fa-solid fa-lock position-absolute start-0 top-50 translate-middle-y ms-2"></i>
+              Private / Corporate
+            </a>
             <a href="#" class="text-center mt-2 flip-trigger">learn more</a>
           </div>
         </div>
@@ -89,14 +93,7 @@
         <link href="//cdn-images.mailchimp.com/embedcode/classic-071822.css" rel="stylesheet" type="text/css" />
 
         <div id="mc_embed_signup">
-          <form
-            action="https://nkdagility.us6.list-manage.com/subscribe/post?u=8f1debed5aa20a5cfafd20918&amp;id=94de9849c1&amp;f_id=00640de3f0"
-            method="post"
-            id="mc-embedded-subscribe-form"
-            name="mc-embedded-subscribe-form"
-            class="validate"
-            target="_blank"
-            novalidate>
+          <form action="https://nkdagility.us6.list-manage.com/subscribe/post?u=8f1debed5aa20a5cfafd20918&amp;id=94de9849c1&amp;f_id=00640de3f0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
             <div id="mc_embed_signup_scroll">
               <h2>Subscribe</h2>
               <div class="indicates-required"><span class="asterisk">*</span> indicates required</div>


### PR DESCRIPTION
✨📝 (book-online/index.md, deliveryfound-summery.html): add links for improved navigation and user engagement

Add a link to the "Working with us" page in the booking section to provide users with more information about the collaboration process. Introduce a new button for private or corporate sessions in the delivery summary to encourage direct engagement. Additionally, refactor the Mailchimp form HTML for better readability and maintainability. These changes aim to enhance user experience by providing clear navigation paths and encouraging interaction with the content.