### PR TITLE
Add badges

### DIFF
--- a/site/layouts/categories/list.html
+++ b/site/layouts/categories/list.html
@@ -46,6 +46,7 @@
             <div class="sectioncards p-2 flex-fill flex-grow-1 h-100">
               <div class="card sectioncards flex-fill flex-grow-1 m-3 shadow text-start small border-0 h-100 position-relative">
                 <div class="card-body p-4 px-20">
+                  <span class="badge text-bg-secondary">{{- title $pageWithData.page.Params.ResourceType }}</span>
                   <h3 class="ttl-nkdagility h5 text-start" title="{{ $title }}">{{- $title }}</h3>
                   <div class="card-text text-muted">
                     {{- $description | markdownify }}
@@ -75,5 +76,5 @@
 {{- end }}
 
 {{- define "template" }}
-  tags/list.html
+  categories/list.html
 {{- end }}

--- a/site/layouts/tags/list.html
+++ b/site/layouts/tags/list.html
@@ -46,6 +46,7 @@
             <div class="sectioncards p-2 flex-fill flex-grow-1 h-100">
               <div class="card sectioncards flex-fill flex-grow-1 m-3 shadow text-start small border-0 h-100 position-relative">
                 <div class="card-body p-4 px-20">
+                  <span class="badge text-bg-secondary">{{- title $pageWithData.page.Params.ResourceType }}</span>
                   <h3 class="ttl-nkdagility h5 text-start" title="{{ $title }}">{{- $title }}</h3>
                   <div class="card-text text-muted">
                     {{- $description | markdownify }}


### PR DESCRIPTION
✨ (layouts): add resource type badge to category and tag cards

Add a badge displaying the resource type to both category and tag cards. This provides users with additional context about the type of content they are viewing, enhancing the user experience by making resource types immediately visible. Additionally, correct the template definition in categories/list.html to ensure proper rendering.