### PR TITLE
BLOG: Why Measuring Individual Cycle Time is Killing Your Flow (And What to Do Instead)

### DIFF
--- a/site/content/resources/blog/2025/2025-03-03-measuring-individual-cycle-time-is-killing-your-flow/data.index.classifications.json
+++ b/site/content/resources/blog/2025/2025-03-03-measuring-individual-cycle-time-is-killing-your-flow/data.index.classifications.json
@@ -1,0 +1,1397 @@
+{
+  "Product Management": {
+    "category": "Product Management",
+    "calculated_at": "2025-03-03T13:57:33",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency, focusing on system metrics rather than product management strategies or methodologies.",
+    "level": "Ignored"
+  },
+  "Scrum": {
+    "category": "Scrum",
+    "calculated_at": "2025-03-03T13:57:36",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "The content primarily discusses Kanban principles and the measurement of individual cycle time, which are not related to Scrum practices or frameworks.",
+    "level": "Ignored"
+  },
+  "Leadership": {
+    "category": "Leadership",
+    "calculated_at": "2025-03-03T13:57:37",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the pitfalls of measuring individual cycle time in Kanban and focuses on system efficiency rather than leadership practices.",
+    "level": "Ignored"
+  },
+  "Kanban": {
+    "category": "Kanban",
+    "calculated_at": "2025-03-03T13:57:39",
+    "ai_confidence": 80,
+    "non_ai_confidence": 50,
+    "final_score": 77.0,
+    "reasoning": "The content primarily discusses Kanban principles, specifically focusing on flow efficiency, work in progress, and systemic improvement, making it a central theme.",
+    "level": "Secondary"
+  },
+  "DevOps": {
+    "category": "DevOps",
+    "calculated_at": "2025-03-03T13:57:45",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and individual cycle time measurement, which are not central to DevOps practices.",
+    "level": "Ignored"
+  },
+  "Engineering Excellence": {
+    "category": "Engineering Excellence",
+    "calculated_at": "2025-03-03T13:57:46",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses the importance of optimising system flow in Kanban, which relates to engineering practices, but the primary focus is on individual cycle time and its implications rather than broader engineering excellence principles.",
+    "level": "Tertiary"
+  },
+  "Social Technologies": {
+    "category": "Social Technologies",
+    "calculated_at": "2025-03-03T13:57:48",
+    "ai_confidence": 80,
+    "non_ai_confidence": 0,
+    "final_score": 72.0,
+    "reasoning": "Content primarily discusses Kanban principles, focusing on flow efficiency, work in progress, and systemic improvement, which are central to the Social Technologies category.",
+    "level": "Secondary"
+  },
+  "Lean Thinking": {
+    "category": "Lean Thinking",
+    "calculated_at": "2025-03-03T13:57:51",
+    "ai_confidence": 80,
+    "non_ai_confidence": 0,
+    "final_score": 72.0,
+    "reasoning": "The content primarily discusses the importance of optimising flow within a system, which aligns with Lean principles. It addresses waste in the form of inefficiencies caused by measuring individual cycle times and promotes a system-wide approach to improvement, reflecting key Lean concepts.",
+    "level": "Secondary"
+  },
+  "Team Motivation": {
+    "category": "Team Motivation",
+    "calculated_at": "2025-03-03T13:57:52",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the pitfalls of measuring individual cycle time in Kanban and focuses on system efficiency rather than team dynamics or motivation.",
+    "level": "Ignored"
+  },
+  "Azure DevOps": {
+    "category": "Azure DevOps",
+    "calculated_at": "2025-03-03T13:57:55",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and individual cycle time metrics, with no mention of Azure DevOps or its functionalities.",
+    "level": "Ignored"
+  },
+  "Daily Scrum": {
+    "category": "Daily Scrum",
+    "calculated_at": "2025-03-03T13:57:58",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and individual cycle time metrics, with no clear focus on Daily Scrum or its related topics.",
+    "level": "Ignored"
+  },
+  "Frequent Releases": {
+    "category": "Frequent Releases",
+    "calculated_at": "2025-03-03T13:58:00",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the concept of flow in Kanban and the pitfalls of measuring individual cycle time, without addressing frequent releases or related practices.",
+    "level": "Ignored"
+  },
+  "Increment": {
+    "category": "Increment",
+    "calculated_at": "2025-03-03T13:58:01",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the concept of cycle time in Kanban and its impact on system flow, rather than focusing on the delivery of software increments or Agile practices related to Scrum.",
+    "level": "Ignored"
+  },
+  "News and Reviews": {
+    "category": "News and Reviews",
+    "calculated_at": "2025-03-03T13:58:03",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses the concept of measuring cycle time in Kanban and its implications on system flow, rather than providing news or reviews related to Agile or DevOps.",
+    "level": "Ignored"
+  },
+  "People and Process": {
+    "category": "People and Process",
+    "calculated_at": "2025-03-03T13:58:05",
+    "ai_confidence": 80,
+    "non_ai_confidence": 30,
+    "final_score": 75.0,
+    "reasoning": "The content primarily discusses the impact of measuring individual cycle time on team dynamics and system efficiency, emphasising the importance of focusing on processes rather than individuals, which aligns well with the category.",
+    "level": "Secondary"
+  },
+  "Empirical Process Control": {
+    "category": "Empirical Process Control",
+    "calculated_at": "2025-03-03T13:58:07",
+    "ai_confidence": 50,
+    "non_ai_confidence": 10,
+    "final_score": 46.0,
+    "reasoning": "The content discusses the importance of measuring system-wide metrics in Kanban, which aligns with the principles of empirical process control, but it primarily focuses on the pitfalls of measuring individual cycle time rather than a comprehensive exploration of empirical process control itself.",
+    "level": "Tertiary"
+  },
+  "Ability to Innovate": {
+    "category": "Ability to Innovate",
+    "calculated_at": "2025-03-03T13:58:08",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses the pitfalls of measuring individual cycle time in Kanban and focuses on system-wide flow efficiency rather than innovation capabilities or Evidence-Based Management.",
+    "level": "Ignored"
+  },
+  "Value Delivery": {
+    "category": "Value Delivery",
+    "calculated_at": "2025-03-03T13:58:10",
+    "ai_confidence": 80,
+    "non_ai_confidence": 10,
+    "final_score": 73.0,
+    "reasoning": "The content primarily discusses the importance of optimising flow in a system rather than focusing on individual metrics, which aligns with value delivery principles in Kanban. It addresses systemic improvements and metrics that enhance overall workflow efficiency, making it a central theme.",
+    "level": "Secondary"
+  },
+  "Install and Configuration": {
+    "category": "Install and Configuration",
+    "calculated_at": "2025-03-03T13:58:12",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses the misconceptions of measuring individual cycle time in Kanban and focuses on system flow rather than installation or configuration of tools.",
+    "level": "Ignored"
+  },
+  "Technical Debt": {
+    "category": "Technical Debt",
+    "calculated_at": "2025-03-03T13:58:15",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses flow efficiency in Kanban and the pitfalls of measuring individual cycle time, without addressing technical debt or its management.",
+    "level": "Ignored"
+  },
+  "Lean": {
+    "category": "Lean",
+    "calculated_at": "2025-03-03T13:58:17",
+    "ai_confidence": 80,
+    "non_ai_confidence": 0,
+    "final_score": 72.0,
+    "reasoning": "The content primarily discusses the importance of optimising flow in a system, which aligns with Lean principles. It addresses waste reduction, system-wide metrics, and the impact of individual measurements on overall efficiency, all of which are central to Lean methodologies.",
+    "level": "Secondary"
+  },
+  "Deployment Frequency": {
+    "category": "Deployment Frequency",
+    "calculated_at": "2025-03-03T13:58:18",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the concept of flow in Kanban and the pitfalls of measuring individual cycle time, which does not directly relate to the optimisation of deployment intervals.",
+    "level": "Ignored"
+  },
+  "Lean Startup": {
+    "category": "Lean Startup",
+    "calculated_at": "2025-03-03T13:58:25",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency, focusing on system metrics rather than Lean Startup principles such as MVP, Build-Measure-Learn, or validated learning.",
+    "level": "Ignored"
+  },
+  "Collaboration Tools": {
+    "category": "Collaboration Tools",
+    "calculated_at": "2025-03-03T13:58:27",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses the concept of cycle time in Kanban and its implications on system flow, rather than focusing on collaboration tools or their impact on Agile team dynamics.",
+    "level": "Ignored"
+  },
+  "Lead Time": {
+    "category": "Lead Time",
+    "calculated_at": "2025-03-03T13:58:29",
+    "ai_confidence": 0,
+    "non_ai_confidence": 20,
+    "final_score": 2.0,
+    "reasoning": "Content primarily discusses cycle time and its implications on flow efficiency, rather than focusing on Lead Time as defined.",
+    "level": "Ignored"
+  },
+  "Agile Philosophy": {
+    "category": "Agile Philosophy",
+    "calculated_at": "2025-03-03T13:58:36",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses the importance of optimising flow in a system rather than focusing on individual metrics, which aligns with Agile principles of collaboration and continuous improvement. However, it primarily centres on Kanban practices rather than the broader Agile philosophy.",
+    "level": "Tertiary"
+  },
+  "Evidence Based Management": {
+    "category": "Evidence Based Management",
+    "calculated_at": "2025-03-03T13:58:37",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses metrics and measurement in the context of Kanban and flow efficiency, which aligns with some principles of Evidence-Based Management, but it primarily focuses on individual cycle time rather than a broader application of EBM principles.",
+    "level": "Tertiary"
+  },
+  "Automated Testing": {
+    "category": "Automated Testing",
+    "calculated_at": "2025-03-03T13:58:39",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency, with no mention of automated testing principles or practices.",
+    "level": "Ignored"
+  },
+  "Complexity Thinking": {
+    "category": "Complexity Thinking",
+    "calculated_at": "2025-03-03T13:58:42",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses systemic flow and the importance of optimising the entire system rather than focusing on individual metrics, which aligns with complexity thinking principles. However, it primarily centres on Kanban practices rather than a broader application of complexity science.",
+    "level": "Tertiary"
+  },
+  "Practical Techniques and Tooling": {
+    "category": "Practical Techniques and Tooling",
+    "calculated_at": "2025-03-03T13:58:44",
+    "ai_confidence": 80,
+    "non_ai_confidence": 10,
+    "final_score": 73.0,
+    "reasoning": "The content primarily discusses the practical application of Kanban principles and metrics to improve system flow, which aligns with the exploration of methodologies and best practices in Agile and DevOps.",
+    "level": "Secondary"
+  },
+  "Sensemaking": {
+    "category": "Sensemaking",
+    "calculated_at": "2025-03-03T13:58:47",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the pitfalls of measuring individual cycle time in Kanban and focuses on system-wide flow efficiency rather than the principles of sensemaking or decision-making in complex environments.",
+    "level": "Ignored"
+  },
+  "Personal": {
+    "category": "Personal",
+    "calculated_at": "2025-03-03T13:58:49",
+    "ai_confidence": 0,
+    "non_ai_confidence": 50,
+    "final_score": 5.0,
+    "reasoning": "Content primarily discusses the technical aspects of measuring cycle time in Kanban and its implications for system efficiency, without personal anecdotes or reflections.",
+    "level": "Ignored"
+  },
+  "Estimation": {
+    "category": "Estimation",
+    "calculated_at": "2025-03-03T13:58:50",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the concept of flow in Kanban and the pitfalls of measuring individual cycle time, without focusing on estimation techniques or practices within Agile or Scrum frameworks.",
+    "level": "Ignored"
+  },
+  "Azure Pipelines": {
+    "category": "Azure Pipelines",
+    "calculated_at": "2025-03-03T13:58:51",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content heavily discusses Kanban principles and individual cycle time metrics, with no mention of Azure Pipelines or related CI/CD practices.",
+    "level": "Ignored"
+  },
+  "Customer Satisfaction": {
+    "category": "Customer Satisfaction",
+    "calculated_at": "2025-03-03T13:58:53",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the importance of measuring system flow in Kanban rather than focusing on customer satisfaction or experience.",
+    "level": "Ignored"
+  },
+  "Scaling Agility": {
+    "category": "Scaling Agility",
+    "calculated_at": "2025-03-03T13:58:54",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses individual cycle time measurement in Kanban and its impact on system flow, without addressing scaling agility or organisational-level practices.",
+    "level": "Ignored"
+  },
+  "Trend Analysis": {
+    "category": "Trend Analysis",
+    "calculated_at": "2025-03-03T13:58:56",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the implications of measuring individual cycle time in Kanban, focusing on system efficiency rather than trend analysis in Agile or DevOps practices.",
+    "level": "Ignored"
+  },
+  "Scrum Values": {
+    "category": "Scrum Values",
+    "calculated_at": "2025-03-03T13:58:58",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and metrics, with no direct relation to Scrum Values.",
+    "level": "Ignored"
+  },
+  "Self Organisation": {
+    "category": "Self Organisation",
+    "calculated_at": "2025-03-03T13:58:59",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the pitfalls of measuring individual cycle time in Kanban and focuses on system-wide flow efficiency rather than self-organisation principles.",
+    "level": "Ignored"
+  },
+  "MVP": {
+    "category": "MVP",
+    "calculated_at": "2025-03-03T13:59:01",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency, with no clear focus on Minimum Viable Product concepts or related strategies.",
+    "level": "Ignored"
+  },
+  "Engineering Practices": {
+    "category": "Engineering Practices",
+    "calculated_at": "2025-03-03T13:59:04",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses the importance of optimising workflow and system metrics in Kanban, which aligns with Agile engineering practices, but it primarily focuses on individual cycle time rather than core engineering methodologies.",
+    "level": "Tertiary"
+  },
+  "Test First Development": {
+    "category": "Test First Development",
+    "calculated_at": "2025-03-03T13:59:05",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency, with no mention of Test First Development or related practices.",
+    "level": "Ignored"
+  },
+  "System Configuration": {
+    "category": "System Configuration",
+    "calculated_at": "2025-03-03T13:59:08",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses Kanban principles and individual cycle time measurement, which are not directly related to system configuration.",
+    "level": "Ignored"
+  },
+  "Transparency and Accountability": {
+    "category": "Transparency and Accountability",
+    "calculated_at": "2025-03-03T13:59:09",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses the pitfalls of measuring individual cycle time in Kanban and focuses on system-wide flow efficiency rather than transparency and accountability within Agile teams.",
+    "level": "Ignored"
+  },
+  "Strategy": {
+    "category": "Strategy",
+    "calculated_at": "2025-03-03T13:59:12",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses the importance of optimising flow in Kanban systems, which aligns with strategic approaches in Agile environments. However, the primary focus is on individual cycle time measurement rather than broader strategic alignment or execution.",
+    "level": "Tertiary"
+  },
+  "Scrum Master": {
+    "category": "Scrum Master",
+    "calculated_at": "2025-03-03T13:59:19",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and metrics, with no direct reference to the Scrum Master role or responsibilities.",
+    "level": "Ignored"
+  },
+  "Employee Engagement": {
+    "category": "Employee Engagement",
+    "calculated_at": "2025-03-03T13:59:21",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the measurement of individual cycle time in Kanban and its impact on system flow, rather than focusing on employee engagement or motivation.",
+    "level": "Ignored"
+  },
+  "Large Scale Agility": {
+    "category": "Large Scale Agility",
+    "calculated_at": "2025-03-03T13:59:23",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses individual cycle time in Kanban and its impact on system flow, without addressing large-scale Agile practices or frameworks.",
+    "level": "Ignored"
+  },
+  "Product Discovery": {
+    "category": "Product Discovery",
+    "calculated_at": "2025-03-03T13:59:25",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency, focusing on system metrics rather than product discovery methodologies or customer needs.",
+    "level": "Ignored"
+  },
+  "Product Strategy": {
+    "category": "Product Strategy",
+    "calculated_at": "2025-03-03T13:59:26",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and individual cycle time measurement, which are not directly related to product strategy or its methodologies.",
+    "level": "Ignored"
+  },
+  "Experimentation": {
+    "category": "Experimentation",
+    "calculated_at": "2025-03-03T13:59:28",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the importance of measuring system flow in Kanban rather than focusing on experimentation or hypothesis-driven approaches.",
+    "level": "Ignored"
+  },
+  "Working Software": {
+    "category": "Working Software",
+    "calculated_at": "2025-03-03T13:59:29",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the concept of flow in Kanban and the pitfalls of measuring individual cycle time, rather than focusing on the delivery of functional software or customer value.",
+    "level": "Ignored"
+  },
+  "Transparency": {
+    "category": "Transparency",
+    "calculated_at": "2025-03-03T13:59:31",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the pitfalls of measuring individual cycle time in Kanban and focuses on system-wide flow efficiency rather than transparency in Agile processes.",
+    "level": "Ignored"
+  },
+  "Scaling Scrum": {
+    "category": "Scaling Scrum",
+    "calculated_at": "2025-03-03T13:59:32",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and individual cycle time measurement, which are not related to scaling Scrum practices.",
+    "level": "Ignored"
+  },
+  "Agile Frameworks": {
+    "category": "Agile Frameworks",
+    "calculated_at": "2025-03-03T13:59:34",
+    "ai_confidence": 80,
+    "non_ai_confidence": 0,
+    "final_score": 72.0,
+    "reasoning": "The content primarily discusses Kanban, an Agile framework, and its principles regarding flow efficiency and system metrics, making it a central topic.",
+    "level": "Secondary"
+  },
+  "Agile Product Operating Model": {
+    "category": "Agile Product Operating Model",
+    "calculated_at": "2025-03-03T13:59:35",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and the measurement of cycle time, focusing on system efficiency rather than the Agile Product Operating Model or product-centric development.",
+    "level": "Ignored"
+  },
+  "Customer Retention": {
+    "category": "Customer Retention",
+    "calculated_at": "2025-03-03T13:59:37",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and the importance of measuring system flow rather than individual performance, with no direct focus on customer retention strategies.",
+    "level": "Ignored"
+  },
+  "Forecasting": {
+    "category": "Forecasting",
+    "calculated_at": "2025-03-03T13:59:38",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the inefficiencies of measuring individual cycle time in Kanban and focuses on system-wide flow rather than forecasting delivery timelines or Agile methodologies.",
+    "level": "Ignored"
+  },
+  "Agile Strategy": {
+    "category": "Agile Strategy",
+    "calculated_at": "2025-03-03T13:59:41",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses Kanban principles and the importance of system-wide metrics over individual metrics, which aligns with Agile methodologies. However, it primarily focuses on technical practices rather than strategic context.",
+    "level": "Tertiary"
+  },
+  "Organisational Culture": {
+    "category": "Organisational Culture",
+    "calculated_at": "2025-03-03T13:59:43",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the measurement of individual cycle time in Kanban and its impact on system flow, without a clear focus on organisational culture or its influence on Agile practices.",
+    "level": "Ignored"
+  },
+  "Scrum Team": {
+    "category": "Scrum Team",
+    "calculated_at": "2025-03-03T13:59:45",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "The content primarily discusses Kanban principles and individual cycle time metrics, which are not specific to Scrum or its team dynamics.",
+    "level": "Ignored"
+  },
+  "Internal Developer Platform": {
+    "category": "Internal Developer Platform",
+    "calculated_at": "2025-03-03T13:59:46",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and individual cycle time metrics, which are not related to Internal Developer Platforms.",
+    "level": "Ignored"
+  },
+  "Cross Functional Teams": {
+    "category": "Cross Functional Teams",
+    "calculated_at": "2025-03-03T13:59:48",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the concept of flow in Kanban and the pitfalls of measuring individual cycle time, without a focus on cross-functional teams or their characteristics.",
+    "level": "Ignored"
+  },
+  "Platform Engineering": {
+    "category": "Platform Engineering",
+    "calculated_at": "2025-03-03T13:59:49",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency, with no clear focus on platform engineering or internal developer platforms.",
+    "level": "Ignored"
+  },
+  "Decision Making": {
+    "category": "Decision Making",
+    "calculated_at": "2025-03-03T13:59:51",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses the implications of measuring individual cycle time on decision-making within a Kanban system, highlighting the importance of system-wide metrics and collaborative approaches. However, the primary focus is on flow efficiency rather than structured decision-making methodologies.",
+    "level": "Tertiary"
+  },
+  "Behaviour Driven Development": {
+    "category": "Behaviour Driven Development",
+    "calculated_at": "2025-03-03T13:59:53",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency, with no mention of Behaviour Driven Development principles or practices.",
+    "level": "Ignored"
+  },
+  "Test Automation": {
+    "category": "Test Automation",
+    "calculated_at": "2025-03-03T13:59:55",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban flow efficiency and the pitfalls of measuring individual cycle time, with no focus on test automation principles, practices, or tools.",
+    "level": "Ignored"
+  },
+  "Product Backlog": {
+    "category": "Product Backlog",
+    "calculated_at": "2025-03-03T13:59:57",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and the importance of system flow, with no focus on Product Backlog management or related Agile practices.",
+    "level": "Ignored"
+  },
+  "Agile Product Management": {
+    "category": "Agile Product Management",
+    "calculated_at": "2025-03-03T13:59:59",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "The content primarily discusses Kanban principles and the importance of system-wide metrics over individual performance, which does not directly relate to Agile Product Management practices or the role of the Product Owner.",
+    "level": "Ignored"
+  },
+  "Resilience and Change": {
+    "category": "Resilience and Change",
+    "calculated_at": "2025-03-03T14:00:00",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses Kanban metrics and the importance of system flow rather than organisational resilience or change management.",
+    "level": "Ignored"
+  },
+  "Backlog Refinement": {
+    "category": "Backlog Refinement",
+    "calculated_at": "2025-03-03T14:00:02",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and the importance of system flow, with no clear focus on backlog refinement or related Agile practices.",
+    "level": "Ignored"
+  },
+  "Revenue per Employee": {
+    "category": "Revenue per Employee",
+    "calculated_at": "2025-03-03T14:00:04",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content heavily discusses cycle time measurement and flow efficiency in Kanban, with no focus on revenue per employee or related financial metrics.",
+    "level": "Ignored"
+  },
+  "Application Lifecycle Management": {
+    "category": "Application Lifecycle Management",
+    "calculated_at": "2025-03-03T14:00:06",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and flow efficiency, which are not directly related to Application Lifecycle Management.",
+    "level": "Ignored"
+  },
+  "Software Development": {
+    "category": "Software Development",
+    "calculated_at": "2025-03-03T14:00:08",
+    "ai_confidence": 80,
+    "non_ai_confidence": 0,
+    "final_score": 72.0,
+    "reasoning": "Content primarily discusses Kanban, a software development methodology, and its implications on workflow efficiency and system metrics, which are central to software development practices.",
+    "level": "Secondary"
+  },
+  "Organisational Psychology": {
+    "category": "Organisational Psychology",
+    "calculated_at": "2025-03-03T14:00:10",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban methodology and the implications of measuring individual cycle time, which are not directly related to psychological principles or theories in organisational behaviour.",
+    "level": "Ignored"
+  },
+  "Professional Scrum": {
+    "category": "Professional Scrum",
+    "calculated_at": "2025-03-03T14:00:11",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "The content primarily discusses Kanban principles and flow efficiency, which are not central to Scrum practices or principles.",
+    "level": "Ignored"
+  },
+  "Strategic Goals": {
+    "category": "Strategic Goals",
+    "calculated_at": "2025-03-03T14:00:13",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the importance of measuring flow efficiency in Kanban systems rather than focusing on long-term strategic goals or business agility.",
+    "level": "Ignored"
+  },
+  "Market Adaptability": {
+    "category": "Market Adaptability",
+    "calculated_at": "2025-03-03T14:00:14",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the importance of measuring system flow in Kanban rather than individual cycle times, focusing on systemic improvements rather than market adaptability strategies.",
+    "level": "Ignored"
+  },
+  "Organisational Physics": {
+    "category": "Organisational Physics",
+    "calculated_at": "2025-03-03T14:00:16",
+    "ai_confidence": 80,
+    "non_ai_confidence": 0,
+    "final_score": 72.0,
+    "reasoning": "The content primarily discusses the importance of understanding flow within a system, the impact of measuring individual performance versus system performance, and the implications for organisational behaviour and efficiency, aligning closely with systems thinking principles.",
+    "level": "Secondary"
+  },
+  "Enterprise Agility": {
+    "category": "Enterprise Agility",
+    "calculated_at": "2025-03-03T14:00:17",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses individual cycle time in Kanban and its impact on system flow, without addressing broader organisational agility or enterprise-level practices.",
+    "level": "Ignored"
+  },
+  "Acceptance Test Driven Development": {
+    "category": "Acceptance Test Driven Development",
+    "calculated_at": "2025-03-03T14:00:19",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency, with no mention of Acceptance Test Driven Development or related concepts.",
+    "level": "Ignored"
+  },
+  "Agile Planning": {
+    "category": "Agile Planning",
+    "calculated_at": "2025-03-03T14:00:21",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses Kanban principles and the importance of optimising system flow, which aligns with Agile Planning concepts, but it primarily focuses on individual cycle time measurement rather than broader Agile Planning methodologies.",
+    "level": "Tertiary"
+  },
+  "Artificial Intelligence": {
+    "category": "Artificial Intelligence",
+    "calculated_at": "2025-03-03T14:00:22",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency in project management, with no mention of AI or its applications in Agile or DevOps.",
+    "level": "Ignored"
+  },
+  "Scaling Kanban": {
+    "category": "Scaling Kanban",
+    "calculated_at": "2025-03-03T14:00:24",
+    "ai_confidence": 50,
+    "non_ai_confidence": 10,
+    "final_score": 46.0,
+    "reasoning": "The content discusses Kanban principles and flow efficiency, which are relevant to scaling Kanban, but it primarily focuses on individual cycle time and its impact on system flow rather than on scaling Kanban practices across multiple teams or departments.",
+    "level": "Tertiary"
+  },
+  "Product Validation": {
+    "category": "Product Validation",
+    "calculated_at": "2025-03-03T14:00:26",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and the importance of measuring system flow rather than individual performance, which does not directly relate to product validation methodologies or practices.",
+    "level": "Ignored"
+  },
+  "Metrics and Learning": {
+    "category": "Metrics and Learning",
+    "calculated_at": "2025-03-03T14:00:27",
+    "ai_confidence": 80,
+    "non_ai_confidence": 10,
+    "final_score": 73.0,
+    "reasoning": "The content primarily discusses the importance of measuring system-wide metrics in Kanban, focusing on flow efficiency and the impact of individual cycle time measurements on team dynamics and system performance.",
+    "level": "Secondary"
+  },
+  "Windows": {
+    "category": "Windows",
+    "calculated_at": "2025-03-03T14:00:29",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency, with no relevance to the Windows operating system.",
+    "level": "Ignored"
+  },
+  "Deployment Strategies": {
+    "category": "Deployment Strategies",
+    "calculated_at": "2025-03-03T14:00:30",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content heavily discusses Kanban principles and individual cycle time measurement, which are not related to deployment strategies.",
+    "level": "Ignored"
+  },
+  "Agile Planning Tools": {
+    "category": "Agile Planning Tools",
+    "calculated_at": "2025-03-03T14:00:32",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the concept of cycle time in Kanban and its implications on system flow, rather than focusing on Agile Planning Tools or methodologies.",
+    "level": "Ignored"
+  },
+  "AI": {
+    "category": "AI",
+    "calculated_at": "2025-03-03T14:00:33",
+    "ai_confidence": 0,
+    "non_ai_confidence": 30,
+    "final_score": 3.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency in project management, with no mention of AI or its application in Agile or DevOps.",
+    "level": "Ignored"
+  },
+  "Change Management": {
+    "category": "Change Management",
+    "calculated_at": "2025-03-03T14:00:35",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the importance of measuring system flow in Kanban rather than individual cycle times, focusing on metrics and behaviours rather than change management strategies or practices.",
+    "level": "Ignored"
+  },
+  "Decision Theory": {
+    "category": "Decision Theory",
+    "calculated_at": "2025-03-03T14:00:37",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and the importance of system metrics over individual metrics, without a focus on decision-making processes or theories.",
+    "level": "Ignored"
+  },
+  "Lean Principles": {
+    "category": "Lean Principles",
+    "calculated_at": "2025-03-03T14:00:39",
+    "ai_confidence": 80,
+    "non_ai_confidence": 0,
+    "final_score": 72.0,
+    "reasoning": "The content primarily discusses the importance of optimising flow in a system, which aligns with Lean principles of waste reduction and value maximisation. It critiques individual cycle time measurement and promotes system-wide metrics, reflecting core Lean concepts.",
+    "level": "Secondary"
+  },
+  "Organisational Change": {
+    "category": "Organisational Change",
+    "calculated_at": "2025-03-03T14:00:41",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban metrics and individual cycle time, which are not central to organisational change processes.",
+    "level": "Ignored"
+  },
+  "Release Management": {
+    "category": "Release Management",
+    "calculated_at": "2025-03-03T14:00:42",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and the importance of system flow rather than focusing on release management strategies or practices.",
+    "level": "Ignored"
+  },
+  "Test Driven Development": {
+    "category": "Test Driven Development",
+    "calculated_at": "2025-03-03T14:00:43",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency, with no mention of Test Driven Development principles or practices.",
+    "level": "Ignored"
+  },
+  "Azure Repos": {
+    "category": "Azure Repos",
+    "calculated_at": "2025-03-03T14:00:45",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban methodologies and individual cycle time metrics, with no direct relevance to Azure Repos or its functionalities.",
+    "level": "Ignored"
+  },
+  "Beta Codex": {
+    "category": "Beta Codex",
+    "calculated_at": "2025-03-03T14:00:46",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and the importance of system-wide metrics over individual performance, which does not align with the core tenets of BetaCodex.",
+    "level": "Ignored"
+  },
+  "Troubleshooting": {
+    "category": "Troubleshooting",
+    "calculated_at": "2025-03-03T14:00:48",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and the importance of system-wide metrics rather than focusing on troubleshooting specific technical issues.",
+    "level": "Ignored"
+  },
+  "Digital Transformation": {
+    "category": "Digital Transformation",
+    "calculated_at": "2025-03-03T14:00:50",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban methodology and the importance of measuring system flow rather than individual performance, which does not directly relate to the strategic use of digital technologies for business transformation.",
+    "level": "Ignored"
+  },
+  "Business Agility": {
+    "category": "Business Agility",
+    "calculated_at": "2025-03-03T14:00:52",
+    "ai_confidence": 50,
+    "non_ai_confidence": 10,
+    "final_score": 46.0,
+    "reasoning": "The content discusses Kanban and flow efficiency, which are related to business agility principles, but the primary focus is on individual cycle time and its implications rather than a broader exploration of business agility practices.",
+    "level": "Tertiary"
+  },
+  "Discovery and Learning": {
+    "category": "Discovery and Learning",
+    "calculated_at": "2025-03-03T14:00:54",
+    "ai_confidence": 50,
+    "non_ai_confidence": 10,
+    "final_score": 46.0,
+    "reasoning": "The content discusses the importance of optimising system flow and understanding metrics in Kanban, which relates to learning from processes and improving team performance. However, the primary focus is on metrics and system efficiency rather than broader themes of discovery and learning.",
+    "level": "Tertiary"
+  },
+  "Pragmatic Thinking": {
+    "category": "Pragmatic Thinking",
+    "calculated_at": "2025-03-03T14:00:56",
+    "ai_confidence": 80,
+    "non_ai_confidence": 0,
+    "final_score": 72.0,
+    "reasoning": "The content primarily discusses practical problem-solving strategies in the context of Kanban, emphasising the importance of system-wide metrics over individual performance. It aligns well with the principles of Agile and DevOps by focusing on optimising workflows and addressing systemic inefficiencies.",
+    "level": "Secondary"
+  },
+  "Sociotechnical Systems": {
+    "category": "Sociotechnical Systems",
+    "calculated_at": "2025-03-03T14:00:57",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses the importance of optimising system flow in Kanban and the negative impact of measuring individual cycle time, which touches on the interplay between social and technical aspects in a team context. However, the primary focus is on Kanban metrics rather than a broader sociotechnical systems analysis.",
+    "level": "Tertiary"
+  },
+  "AI and Automation in Agility": {
+    "category": "AI and Automation in Agility",
+    "calculated_at": "2025-03-03T14:00:59",
+    "ai_confidence": 0,
+    "non_ai_confidence": 30,
+    "final_score": 3.0,
+    "reasoning": "Content primarily discusses Kanban principles and the importance of system-wide metrics over individual performance, without any mention of AI or automation.",
+    "level": "Ignored"
+  },
+  "Cycle Time": {
+    "category": "Cycle Time",
+    "calculated_at": "2025-03-03T14:01:00",
+    "ai_confidence": 80,
+    "non_ai_confidence": 20,
+    "final_score": 74.0,
+    "reasoning": "The content primarily discusses the implications of measuring individual cycle time and advocates for a system-wide approach, making Cycle Time a central theme.",
+    "level": "Secondary"
+  },
+  "Sprint Review": {
+    "category": "Sprint Review",
+    "calculated_at": "2025-03-03T14:01:02",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and individual cycle time metrics, which are unrelated to the Sprint Review process in Scrum.",
+    "level": "Ignored"
+  },
+  "Technical Leadership": {
+    "category": "Technical Leadership",
+    "calculated_at": "2025-03-03T14:01:04",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the concept of measuring cycle time in Kanban and its implications on system flow, rather than focusing on technical leadership principles or agile methodologies.",
+    "level": "Ignored"
+  },
+  "Hypothesis Driven Development": {
+    "category": "Hypothesis Driven Development",
+    "calculated_at": "2025-03-03T14:01:06",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the importance of system metrics in Kanban and criticises the measurement of individual cycle time, without focusing on hypothesis formulation or experimentation.",
+    "level": "Ignored"
+  },
+  "Scrum Product Development": {
+    "category": "Scrum Product Development",
+    "calculated_at": "2025-03-03T14:01:07",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "The content primarily discusses Kanban principles and the measurement of cycle time, which are not directly related to Scrum practices or product development within a Scrum framework.",
+    "level": "Ignored"
+  },
+  "Throughput": {
+    "category": "Throughput",
+    "calculated_at": "2025-03-03T14:01:09",
+    "ai_confidence": 80,
+    "non_ai_confidence": 30,
+    "final_score": 75.0,
+    "reasoning": "The content primarily discusses the importance of measuring system-wide cycle time and throughput in Kanban, emphasising the optimisation of flow and the impact of work in progress (WIP) on overall system efficiency.",
+    "level": "Secondary"
+  },
+  "Continuous Integration": {
+    "category": "Continuous Integration",
+    "calculated_at": "2025-03-03T14:01:10",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and the importance of measuring system flow rather than individual cycle times, which is unrelated to Continuous Integration.",
+    "level": "Ignored"
+  },
+  "Agile Transformation": {
+    "category": "Agile Transformation",
+    "calculated_at": "2025-03-03T14:01:12",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses Kanban principles and the importance of system-wide metrics over individual performance, which aligns with Agile transformation themes, but it primarily focuses on flow efficiency rather than broader Agile transformation strategies.",
+    "level": "Tertiary"
+  },
+  "Site Reliability Engineering": {
+    "category": "Site Reliability Engineering",
+    "calculated_at": "2025-03-03T14:01:14",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency, which are not directly related to Site Reliability Engineering principles or practices.",
+    "level": "Ignored"
+  },
+  "Lean Product Development": {
+    "category": "Lean Product Development",
+    "calculated_at": "2025-03-03T14:01:15",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses flow efficiency and system metrics in the context of Kanban, which aligns with Lean principles of optimising processes and reducing waste. However, it primarily focuses on individual cycle time rather than broader Lean Product Development practices.",
+    "level": "Tertiary"
+  },
+  "Value Stream Management": {
+    "category": "Value Stream Management",
+    "calculated_at": "2025-03-03T14:01:17",
+    "ai_confidence": 80,
+    "non_ai_confidence": 10,
+    "final_score": 73.0,
+    "reasoning": "The content primarily discusses the importance of optimising flow within a system, which aligns closely with Value Stream Management principles. It addresses systemic inefficiencies and the need to measure flow across the entire value stream rather than focusing on individual metrics.",
+    "level": "Secondary"
+  },
+  "Entrepreneurship": {
+    "category": "Entrepreneurship",
+    "calculated_at": "2025-03-03T14:01:19",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban methodology and flow efficiency, which are not directly related to entrepreneurship principles or practices.",
+    "level": "Ignored"
+  },
+  "Portfolio Management": {
+    "category": "Portfolio Management",
+    "calculated_at": "2025-03-03T14:01:21",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency, focusing on individual cycle time rather than portfolio management practices or strategic alignment.",
+    "level": "Ignored"
+  },
+  "Customer Feedback Loops": {
+    "category": "Customer Feedback Loops",
+    "calculated_at": "2025-03-03T14:01:22",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the concept of cycle time in Kanban and its implications for system flow, without addressing customer feedback mechanisms or practices.",
+    "level": "Ignored"
+  },
+  "Agile Leadership": {
+    "category": "Agile Leadership",
+    "calculated_at": "2025-03-03T14:01:24",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban metrics and flow efficiency, with no clear focus on Agile leadership roles or practices.",
+    "level": "Ignored"
+  },
+  "Events and Presentations": {
+    "category": "Events and Presentations",
+    "calculated_at": "2025-03-03T14:01:25",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses the concept of measuring cycle time in Kanban and its implications on workflow, without reference to any specific events, presentations, or discussions related to Agile or DevOps.",
+    "level": "Ignored"
+  },
+  "Remote Working": {
+    "category": "Remote Working",
+    "calculated_at": "2025-03-03T14:01:27",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and the importance of system-wide metrics rather than focusing on remote working practices or Agile methodologies in a distributed context.",
+    "level": "Ignored"
+  },
+  "Modern Source Control": {
+    "category": "Modern Source Control",
+    "calculated_at": "2025-03-03T14:01:29",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency, which are not directly related to version control practices.",
+    "level": "Ignored"
+  },
+  "Products and Books": {
+    "category": "Products and Books",
+    "calculated_at": "2025-03-03T14:01:30",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses the concept of flow in Kanban and the pitfalls of measuring individual cycle time, without focusing on specific products or literature related to Agile or DevOps.",
+    "level": "Ignored"
+  },
+  "Software Developers": {
+    "category": "Software Developers",
+    "calculated_at": "2025-03-03T14:01:31",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses Kanban and flow efficiency, which are relevant to Agile methodologies, but it primarily focuses on system metrics rather than the role of software developers specifically.",
+    "level": "Tertiary"
+  },
+  "One Engineering System (1ES)": {
+    "category": "One Engineering System (1ES)",
+    "calculated_at": "2025-03-03T14:01:33",
+    "ai_confidence": 0,
+    "non_ai_confidence": 20,
+    "final_score": 2.0,
+    "reasoning": "Content primarily discusses Kanban and individual cycle time metrics, which are not central to the One Engineering System framework.",
+    "level": "Ignored"
+  },
+  "Definition of Ready": {
+    "category": "Definition of Ready",
+    "calculated_at": "2025-03-03T14:01:35",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses the concept of measuring individual cycle time in Kanban and its impact on system flow, without addressing the Definition of Ready or its criteria.",
+    "level": "Ignored"
+  },
+  "Product Owner": {
+    "category": "Product Owner",
+    "calculated_at": "2025-03-03T14:01:37",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and flow efficiency, with no clear focus on the responsibilities or practices of a Product Owner.",
+    "level": "Ignored"
+  },
+  "Agile Project Management": {
+    "category": "Agile Project Management",
+    "calculated_at": "2025-03-03T14:01:39",
+    "ai_confidence": 80,
+    "non_ai_confidence": 0,
+    "final_score": 72.0,
+    "reasoning": "Content primarily discusses Kanban principles and the importance of optimising workflow in an agile context, focusing on system metrics rather than individual performance.",
+    "level": "Secondary"
+  },
+  "Product Delivery": {
+    "category": "Product Delivery",
+    "calculated_at": "2025-03-03T14:01:41",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses flow efficiency and system metrics in the context of Kanban, which relates to product delivery methodologies, but it primarily focuses on individual cycle time rather than the broader aspects of product delivery.",
+    "level": "Tertiary"
+  },
+  "Agile Values and Principles": {
+    "category": "Agile Values and Principles",
+    "calculated_at": "2025-03-03T14:01:43",
+    "ai_confidence": 50,
+    "non_ai_confidence": 10,
+    "final_score": 46.0,
+    "reasoning": "The content discusses the importance of optimising flow in a system rather than focusing on individual metrics, which aligns with Agile principles of collaboration and system improvement. However, it primarily centres on Kanban practices rather than the core Agile values and principles.",
+    "level": "Tertiary"
+  },
+  "Team Collaboration": {
+    "category": "Team Collaboration",
+    "calculated_at": "2025-03-03T14:01:44",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses the pitfalls of measuring individual cycle time in Kanban, focusing on system efficiency rather than team collaboration or dynamics.",
+    "level": "Ignored"
+  },
+  "Technical Excellence": {
+    "category": "Technical Excellence",
+    "calculated_at": "2025-03-03T14:01:46",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses Kanban and flow efficiency, which are related to engineering practices, but the primary focus is on individual cycle time and its implications rather than on technical excellence methodologies like TDD or CI/CD.",
+    "level": "Tertiary"
+  },
+  "Value Stream Mapping": {
+    "category": "Value Stream Mapping",
+    "calculated_at": "2025-03-03T14:01:48",
+    "ai_confidence": 50,
+    "non_ai_confidence": 10,
+    "final_score": 46.0,
+    "reasoning": "The content discusses flow efficiency and system-wide cycle time, which are relevant to Value Stream Mapping principles, but the primary focus is on Kanban and individual metrics rather than VSM itself.",
+    "level": "Tertiary"
+  },
+  "Operational Practices": {
+    "category": "Operational Practices",
+    "calculated_at": "2025-03-03T14:01:49",
+    "ai_confidence": 80,
+    "non_ai_confidence": 0,
+    "final_score": 72.0,
+    "reasoning": "The content primarily discusses the importance of measuring system-wide flow efficiency in Kanban, focusing on techniques to optimise workflows and reduce bottlenecks, which aligns well with operational practices.",
+    "level": "Secondary"
+  },
+  "Azure Boards": {
+    "category": "Azure Boards",
+    "calculated_at": "2025-03-03T14:01:51",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and individual cycle time metrics, which are not directly related to Azure Boards or its functionalities in Agile project management.",
+    "level": "Ignored"
+  },
+  "Mentoring": {
+    "category": "Mentoring",
+    "calculated_at": "2025-03-03T14:01:52",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the implications of measuring individual cycle time in Kanban and focuses on system efficiency rather than mentoring or coaching practices.",
+    "level": "Ignored"
+  },
+  "Definition of Done": {
+    "category": "Definition of Done",
+    "calculated_at": "2025-03-03T14:01:54",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses the concept of measuring individual cycle time in Kanban and its implications on system flow, without any mention of the Definition of Done or its related criteria.",
+    "level": "Ignored"
+  },
+  "Market Share": {
+    "category": "Market Share",
+    "calculated_at": "2025-03-03T14:01:56",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban methodology and the importance of measuring system flow rather than individual performance, with no direct relevance to market share strategies or competitive advantage.",
+    "level": "Ignored"
+  },
+  "Code and Complexity": {
+    "category": "Code and Complexity",
+    "calculated_at": "2025-03-03T14:01:58",
+    "ai_confidence": 0,
+    "non_ai_confidence": 10,
+    "final_score": 1.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency in systems, focusing on process improvement rather than code quality or complexity.",
+    "level": "Ignored"
+  },
+  "Team Performance": {
+    "category": "Team Performance",
+    "calculated_at": "2025-03-03T14:02:01",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses the importance of optimising team workflow and collaboration in a Kanban system, which relates to team performance, but it primarily focuses on individual cycle time metrics rather than team dynamics or collaboration strategies.",
+    "level": "Tertiary"
+  },
+  "Evidence Based Leadership": {
+    "category": "Evidence Based Leadership",
+    "calculated_at": "2025-03-03T14:02:02",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban metrics and flow efficiency, without a clear focus on evidence-based leadership principles or practices.",
+    "level": "Ignored"
+  },
+  "Miscellaneous": {
+    "category": "Miscellaneous",
+    "calculated_at": "2025-03-03T14:02:04",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content heavily discusses Kanban principles and metrics, focusing on system-wide flow rather than individual performance, which aligns with Agile methodologies.",
+    "level": "Ignored"
+  },
+  "Coaching": {
+    "category": "Coaching",
+    "calculated_at": "2025-03-03T14:02:05",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the importance of system metrics in Kanban and critiques measuring individual cycle time, rather than focusing on coaching practices or team development.",
+    "level": "Ignored"
+  },
+  "Working Agreements": {
+    "category": "Working Agreements",
+    "calculated_at": "2025-03-03T14:02:07",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the pitfalls of measuring individual cycle time in Kanban and focuses on system efficiency rather than teamwork norms or working agreements.",
+    "level": "Ignored"
+  },
+  "Continuous Delivery": {
+    "category": "Continuous Delivery",
+    "calculated_at": "2025-03-03T14:02:08",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban principles and the importance of measuring system flow rather than individual cycle times, which is not directly related to Continuous Delivery.",
+    "level": "Ignored"
+  },
+  "Systems Thinking": {
+    "category": "Systems Thinking",
+    "calculated_at": "2025-03-03T14:02:10",
+    "ai_confidence": 80,
+    "non_ai_confidence": 0,
+    "final_score": 72.0,
+    "reasoning": "The content primarily discusses the importance of viewing cycle time from a systems perspective rather than an individual one, emphasising the interconnectedness of processes and the need for holistic analysis in improving workflow efficiency.",
+    "level": "Secondary"
+  },
+  "Accountability": {
+    "category": "Accountability",
+    "calculated_at": "2025-03-03T14:02:12",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses the importance of focusing on system metrics rather than individual performance, which relates to accountability in terms of ownership and responsibility within teams. However, the primary focus is on flow efficiency and Kanban practices, making accountability a secondary theme.",
+    "level": "Tertiary"
+  },
+  "Organisational Agility": {
+    "category": "Organisational Agility",
+    "calculated_at": "2025-03-03T14:02:13",
+    "ai_confidence": 80,
+    "non_ai_confidence": 10,
+    "final_score": 73.0,
+    "reasoning": "The content primarily discusses the importance of optimising system flow in Kanban, which aligns with agile principles of organisational agility. It focuses on systemic improvements rather than individual metrics, emphasising collaboration and continuous improvement, which are key aspects of agility.",
+    "level": "Secondary"
+  },
+  "Asynchronous Development": {
+    "category": "Asynchronous Development",
+    "calculated_at": "2025-03-03T14:02:15",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and flow efficiency, focusing on individual versus system metrics, without addressing asynchronous development principles or practices.",
+    "level": "Ignored"
+  },
+  "Scaled Agile": {
+    "category": "Scaled Agile",
+    "calculated_at": "2025-03-03T14:02:17",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses Kanban and individual cycle time metrics, without reference to scaling Agile practices or coordination among multiple teams.",
+    "level": "Ignored"
+  },
+  "Flow Efficiency": {
+    "category": "Flow Efficiency",
+    "calculated_at": "2025-03-03T14:02:18",
+    "ai_confidence": 90,
+    "non_ai_confidence": 20,
+    "final_score": 83.0,
+    "reasoning": "The content primarily discusses the importance of flow efficiency in a system, critiques the measurement of individual cycle time, and emphasises optimising the entire workflow rather than individual performance. It aligns closely with the principles and techniques of flow efficiency.",
+    "level": "Primary"
+  },
+  "Continuous Learning": {
+    "category": "Continuous Learning",
+    "calculated_at": "2025-03-03T14:02:22",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses the importance of optimising systems over individual performance, which aligns with the principles of Continuous Learning, but the primary focus is on Kanban metrics rather than explicit continuous learning practices.",
+    "level": "Tertiary"
+  },
+  "Psychological Safety": {
+    "category": "Psychological Safety",
+    "calculated_at": "2025-03-03T14:02:24",
+    "ai_confidence": 0,
+    "non_ai_confidence": 0,
+    "final_score": 0.0,
+    "reasoning": "Content primarily discusses the inefficiencies of measuring individual cycle time in Kanban and focuses on system metrics rather than psychological safety or team dynamics.",
+    "level": "Ignored"
+  },
+  "Technical Mastery": {
+    "category": "Technical Mastery",
+    "calculated_at": "2025-03-03T14:02:26",
+    "ai_confidence": 50,
+    "non_ai_confidence": 0,
+    "final_score": 45.0,
+    "reasoning": "The content discusses Kanban principles and flow efficiency, which are relevant to software craftsmanship and engineering practices, but the primary focus is on individual cycle time measurement rather than broader technical mastery topics.",
+    "level": "Tertiary"
+  }
+}

--- a/site/content/resources/blog/2025/2025-03-03-measuring-individual-cycle-time-is-killing-your-flow/index.md
+++ b/site/content/resources/blog/2025/2025-03-03-measuring-individual-cycle-time-is-killing-your-flow/index.md
@@ -1,0 +1,93 @@
+---
+title: Why Measuring Individual Cycle Time is Killing Your Flow (And What to Do Instead)
+description: Measuring individual cycle time is a fundamental misunderstanding of flow in a system. Learn why flow efficiency matters and how to measure the right things in Kanban.
+ResourceId: KHEPBWiFDKJ
+ResourceType: blog
+ResourceImport: false
+date: 2025-03-03T09:00:00
+weight: 775
+AudioNative: true
+creator: Martin Hinshelwood
+contributors:
+  - name: Nigel Thurlow
+    external: https://www.linkedin.com/in/nigelthurlow/
+layout: blog
+resourceTypes: blog
+slug: measuring-individual-cycle-time-is-killing-your-flow
+aliases:
+  - /resources/KHEPBWiFDKJ
+aliasesArchive:
+  - /measuring-individual-cycle-time-is-killing-your-flow
+  - /blog/measuring-individual-cycle-time-is-killing-your-flow
+  - /why-measuring-individual-cycle-time-is-killing-your-flow-(and-what-to-do-instead)
+  - /blog/why-measuring-individual-cycle-time-is-killing-your-flow-(and-what-to-do-instead)
+categories:
+  - Kanban
+  - Social Technologies
+tags:
+  - Flow Efficiency
+---
+
+Looking at cycle time for an individual is a fundamental misunderstanding of how flow works in a system—unless the individual is the system. And here is why!
+
+## Flow Efficiency is a System Metric, Not an Individual One
+
+Kanban isn’t about individual productivity; it’s about optimising the flow of work through a system. When you measure an individual’s cycle time, you ignore the real bottlenecks—queues, dependencies, and wait times that slow everything down. A person might complete tasks quickly, but if those tasks get stuck waiting for reviews, approvals, or other handoffs, the overall system remains inefficient. If you want faster delivery, fix the system, not the people.
+
+As Nigel Thurlow puts it: _"You never measure a person, ever. You only ever measure a process. You improve the system, never the people within it. If you're measuring an individual person to try and blame them, then you're ignoring what's wrong with the process that's causing it."_
+
+## Encourages Local Optimisation Over System Improvement
+
+Measuring individual cycle time leads to bad incentives. If someone is judged on how fast they complete their own tasks, they’ll prioritise speed over impact. This can lead to:
+
+- Focusing on tasks that make them look efficient rather than what benefits the team.
+- Taking on work too early, creating unnecessary work in progress (WIP).
+- Cherry-picking simple tasks to appear fast rather than tackling what actually moves the system forward.
+
+Kanban is about improving the whole workflow. Look at system-wide cycle time instead.
+
+## Ignores Work in Progress (WIP) and Blockers
+
+A fast-moving individual doesn’t mean fast-moving work. If the system is overloaded with WIP, nothing gets delivered faster. Work often gets stuck in queues, waiting for handoffs, or blocked by dependencies. Measuring individual cycle time won’t tell you where the real problems are.
+
+Instead, track:
+
+- **Total WIP**—to ensure the system isn’t overloaded.
+- **Time in queue vs. time in progress**—to identify bottlenecks.
+- **Blocked work items**—to find systemic delays.
+
+## Misrepresents Collaboration and Dependencies
+
+Knowledge work isn’t assembly-line work. It requires handoffs, reviews, and collaboration. Measuring an individual’s cycle time isolates their part of the work but ignores the time it spends waiting on others. Worse, it discourages teamwork—if people are penalised for long cycle times, they’ll avoid collaborating because it slows them down.
+
+Optimise for flow across the system, not just individual speed.
+
+## Creates Unintended Behaviour
+
+If people are measured by their personal cycle time, they may:
+
+- **Rush work**, sacrificing quality to look fast.
+- **Avoid complex or high-value tasks**, because they take longer.
+- **Hoard work**, keeping tasks they know they can finish quickly rather than distributing work across the team.
+
+None of this improves system flow. It just distorts behaviour.
+
+## What Should You Measure Instead?
+
+If you want to improve flow, focus on:
+
+- **System-wide cycle time**—how long work takes from start to finish, across the entire value stream.
+- **Work in progress (WIP) limits**—to reduce bottlenecks and improve flow.
+- **Flow efficiency**—the ratio of active work time to waiting time.
+- **Bottlenecks and blockers**—to identify systemic constraints.
+- **Throughput**—the rate at which work is actually completed.
+
+## Bottom Line
+
+Kanban is about improving the system, not monitoring individuals. Measuring individual cycle time distracts from real systemic inefficiencies and leads to bad behaviours. Instead, optimise for end-to-end flow and make sure work moves smoothly across the whole system.
+
+As Thurlow emphasises: _"If there are training or skill gaps, that’s a system problem, not a person problem. Someone failed the person by not providing the right training, support, or experience."_ This reinforces why the focus should always be on fixing the system, not blaming individuals.
+
+### Want to improve your Kanban flow?
+
+If you need help setting up meaningful Kanban metrics, let’s talk. We can identify the right measurements to improve your system without falling into the trap of individual cycle time metrics.

--- a/site/content/resources/blog/2025/2025-03-03-measuring-individual-cycle-time-is-killing-your-flow/index.md
+++ b/site/content/resources/blog/2025/2025-03-03-measuring-individual-cycle-time-is-killing-your-flow/index.md
@@ -30,7 +30,7 @@ tags:
 
 Looking at cycle time for an individual is a fundamental misunderstanding of how flow works in a system—unless the individual is the system. And here is why!
 
-## Flow Efficiency is a System Metric, Not an Individual One
+## Process Cycle Efficiency (PCE) Drives Flow, Not Individual Productivity
 
 Kanban isn’t about individual productivity; it’s about optimising the flow of work through a system. When you measure an individual’s cycle time, you ignore the real bottlenecks—queues, dependencies, and wait times that slow everything down. A person might complete tasks quickly, but if those tasks get stuck waiting for reviews, approvals, or other handoffs, the overall system remains inefficient. If you want faster delivery, fix the system, not the people.
 
@@ -44,7 +44,7 @@ Measuring individual cycle time leads to bad incentives. If someone is judged on
 - Taking on work too early, creating unnecessary work in progress (WIP).
 - Cherry-picking simple tasks to appear fast rather than tackling what actually moves the system forward.
 
-Kanban is about improving the whole workflow. Look at system-wide cycle time instead.
+Kanban is about improving the whole workflow. Look at Process Cycle Efficiency (PCE) and Throughput together—one improves the other.
 
 ## Ignores Work in Progress (WIP) and Blockers
 
@@ -74,11 +74,13 @@ None of this improves system flow. It just distorts behaviour.
 
 ## What Should You Measure Instead?
 
+> At the end of the day, the Kanban Method (as opposed to kanban) is designed to improve flow (basically Process Cycle Efficiency) by improving throughput (units per unit time) by removing constraints (which includes bottlenecks) in the system. Make the system more effective by making it more efficient. - Nigel Thurlow
+
 If you want to improve flow, focus on:
 
-- **System-wide cycle time**—how long work takes from start to finish, across the entire value stream.
+- **customer lead time (time to market)**—the total time from when work is requested to when it is delivered to the customer.
 - **Work in progress (WIP) limits**—to reduce bottlenecks and improve flow.
-- **Flow efficiency**—the ratio of active work time to waiting time.
+- **Process Cycle Efficiency (PCE)**—the ratio of active work time to waiting time.
 - **Bottlenecks and blockers**—to identify systemic constraints.
 - **Throughput**—the rate at which work is actually completed.
 


### PR DESCRIPTION
📝 (blog): add new blog post on measuring cycle time in Kanban

Introduce a new blog post titled "Why Measuring Individual Cycle Time is Killing Your Flow (And What to Do Instead)" to educate readers on the pitfalls of focusing on individual cycle time in Kanban systems. The post emphasizes the importance of system-wide metrics like flow efficiency, work in progress limits, and throughput to improve overall workflow efficiency. It aims to shift the focus from individual performance to systemic improvements, aligning with Kanban principles and promoting better team dynamics and collaboration.