### PR TITLE
Enable age check on watermark refresh... adds rolling watermark of 20 days for now... should increase later.

### DIFF
--- a/.powershell/_includes/ClassificationHelpers.ps1
+++ b/.powershell/_includes/ClassificationHelpers.ps1
@@ -302,7 +302,7 @@ function Get-CategoryConfidenceWithChecksum {
                 $result = Get-ConfidenceFromAIResponse -AIResponseJson $aiResponseJson -ResourceTitle $ResourceTitle -ResourceContent $ResourceContent
                 if ($result.reasoning -ne $null -and $result.category -ne "unknown") {
                     $oldConfidence = $cachedData[$result.category]?.ai_confidence ?? 0
-                    $DaysAgo = [math]::Round(([DateTimeOffset]::Now - [DateTimeOffset]$result.calculated_at).TotalDays)
+                    $DaysAgo = [math]::Round(([DateTimeOffset]::Now - [DateTimeOffset]$cachedData[$result.category].calculated_at).TotalDays)
                     Write-InformationLog "Updating {category} with confidence of {old} calculated {daysago} to new confidence of {confidence} " -PropertyValues $result.category, $oldConfidence, $DaysAgo, $result.ai_confidence
                     $CatalogFromCache[$result.category] = $result
                     $cachedData[$result.category] = $result

--- a/.powershell/_includes/ClassificationHelpers.ps1
+++ b/.powershell/_includes/ClassificationHelpers.ps1
@@ -578,4 +578,5 @@ function Remove-ClassificationsFromCacheThatLookBroken {
             }
         }
 
-
+    }
+}

--- a/.powershell/_includes/ClassificationHelpers.ps1
+++ b/.powershell/_includes/ClassificationHelpers.ps1
@@ -302,7 +302,8 @@ function Get-CategoryConfidenceWithChecksum {
                 $result = Get-ConfidenceFromAIResponse -AIResponseJson $aiResponseJson -ResourceTitle $ResourceTitle -ResourceContent $ResourceContent
                 if ($result.reasoning -ne $null -and $result.category -ne "unknown") {
                     $oldConfidence = $cachedData[$result.category]?.ai_confidence ?? 0
-                    Write-InformationLog "Updating {category} with confidence of {old} to new confidence of {confidence} " -PropertyValues $result.category, $oldConfidence, $result.ai_confidence
+                    $DaysAgo = [math]::Round(([DateTimeOffset]::Now - [DateTimeOffset]$result.calculated_at).TotalDays)
+                    Write-InformationLog "Updating {category} with confidence of {old} calculated {daysago} to new confidence of {confidence} " -PropertyValues $result.category, $oldConfidence, $DaysAgo, $result.ai_confidence
                     $CatalogFromCache[$result.category] = $result
                     $cachedData[$result.category] = $result
                     # Save cache after each API call


### PR DESCRIPTION
♻️ (ClassificationHelpers.ps1): refactor cache removal logic and add age limit for catalog items

Introduce a new variable `$watermarkAgeLimit` to filter catalog items based on age, ensuring only items older than a specified number of days are considered for refresh. This change helps manage the cache more efficiently by focusing on outdated items. Additionally, refactor the cache removal logic to ensure the cache file is only updated when necessary, reducing unnecessary writes and improving performance.