### PR TITLE
🔧 (main.yaml): add site size calculation to GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -461,12 +461,15 @@ jobs:
           }
 
       - name: "Find  files"
+        id: files
         shell: pwsh
         run: |
           Get-ChildItem -Path ".\" -File
           $path = "./_site"
           $size = (Get-ChildItem -Path $path -Recurse | Measure-Object -Property Length -Sum).Sum
-          "{0:N2} MB" -f ($size / 1MB)
+          $sizeOnDisk = "{0:N2} MB" -f ($size / 1MB)
+          $sizeOnDisk
+          echo "sizeOnDisk=$sizeOnDisk" >> $env:GITHUB_OUTPUT
 
       - uses: actions/create-github-app-token@v1
         id: app-token
@@ -498,6 +501,6 @@ jobs:
           $markdown = @"
               ## ${{needs.Setup.outputs.GitVersion_SemVer}} (${{needs.Setup.outputs.nkdAgility_Ring}})
              Deployed to [${{steps.azureDeploy.outputs.static_web_app_url}}](${{steps.azureDeploy.outputs.static_web_app_url}})
-
+             Files on Disk: ${{steps.files.outputs.sizeOnDisk}}
           "@
           echo $markdown >> $Env:GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Add a step in the GitHub Actions workflow to calculate and display the size of the `_site` directory. This provides insight into the deployment size, which can be useful for monitoring and optimizing the build process. The size is formatted in megabytes for readability.