### PR TITLE
Bring cards to resource lists

### DIFF
--- a/site/layouts/partials/components/cards/taxonomy.html
+++ b/site/layouts/partials/components/cards/taxonomy.html
@@ -1,0 +1,60 @@
+<!-- layouts/partials/card.html -->
+{{- $context := .context }}
+{{- $subTypes := .subTypes }}
+{{- $items := where .context.Pages.ByWeight "Draft" "!=" true -}}
+{{- if $subTypes}}
+  {{- $items = where $items "Params.ResourceType" "in" $subTypes -}}
+{{- end }}
+{{- $count := len ($items) -}}
+{{- if gt $count 0 }}    
+  <div class="m-1 card sectioncards shadow text-start flex-fill flex-grow-1 small border-0 h-100 position-relative">
+    <div class="card-body p-4 px-20">
+      <h3 class="ttl-nkdagility h5 text-start" title="{{- $context.Page.Title }}">
+        {{- if $context.Page.Params.card }}
+          {{- $context.Page.Params.card.title }}
+        {{- else }}
+          {{- $context.Page.Title }}
+        {{- end }}
+      </h3>
+      <div class="card-text text-muted">
+        {{- if $context.Page.Params.card }}
+          {{- $context.Page.Params.card.content | markdownify }}
+        {{- else }}
+          {{- $context.Page.Description | markdownify }}
+        {{- end }}
+      </div>
+    </div>
+    <ul class="list-group list-group-flush">
+      {{- range $item := first 5 $items }}
+        <li class="list-group-item d-flex align-items-center">
+          {{ if eq .Params.ResourceType "videos" }}
+                <i class="fa-solid fa-video pe-1"></i>
+              {{ else if eq .Params.ResourceType "blog" }}
+                <i class="fa-solid fa-newspaper pe-1"></i>
+              {{ else }}
+              <i class="fa-solid fa-{{ .Params.ResourceType }}"></i>
+              {{ end }}
+              {{ if .Draft }}
+                <i class="fa-brands fa-firstdraft pe-1"></i>
+              {{ end }}
+              {{ if gt .Date (now) }}
+                <i class="fa-regular fa-flux-capacitor pe-1"></i>
+              {{ end }}
+          <a href="{{- $item.Permalink }}" class="text-decoration-none  text-nowrap text-truncate" title="{{- $item.Title }}">
+            {{- if $item.Params.shorttitle }}
+              {{- $item.Params.shorttitle }}
+            {{- else }}
+              {{- $item.Title }}
+            {{- end }}
+          </a>
+        </li>
+      {{- end }}
+    </ul>
+    {{- if $context.Page.RelPermalink }}
+      <div class="card-footer border-transparent bg-white p-3 text-end border-0">
+        <a href="{{- $context.Page.RelPermalink }}" class="btn btn-nkdagility p-2" title="More information on {{- $context.Page.Title }}">See all {{ $count }} <i class="fa-solid fa-arrow-right"></i></a>
+      </div>
+    {{- end }}
+  </div>
+{{- end }}
+

--- a/site/layouts/partials/main-menu-resources.html
+++ b/site/layouts/partials/main-menu-resources.html
@@ -12,6 +12,7 @@
             <h5>{{- $resources.Title }}</h5>
             <p>{{- $resources.Description }}</p>
             <ul class="list-group">
+              <li class="list-group-item"><a href="/resources">Overview </a></li>
               {{- range $sortedPages }}
                 {{- $count :=  len (where .Pages "Draft" "!=" true) }}
                 {{- if gt $count 0 }}
@@ -106,14 +107,3 @@
     </div>
   </div>
 </li>
-<style>
-  .columns-2 {
-    column-count: 2;
-  }
-  .columns-3 {
-    column-count: 3;
-  }
-  .columns-4 {
-    column-count: 4;
-  }
-</style>

--- a/site/layouts/resources/list.html
+++ b/site/layouts/resources/list.html
@@ -114,23 +114,18 @@
       </div>
       <div class="m-1 small">
         <h5>Categories</h5>
-        <div class="columns-3">
-          
+        <div class="row">
           {{ range $category, $pages := .Site.Taxonomies.categories }}
-            {{- $items := where $pages "Draft" "!=" true -}}
-            {{- if $ResourceTypes}}
-              {{- $items = where $items "Params.ResourceType" $ResourceTypes -}}
-            {{- end }}
-            {{- $count := len ($items) -}}
-            {{- if gt $count 0 }}
-            <div class="d-flex align-items-center">
-              <span class="text-truncate d-inline-block" style="max-width: 100%;" title="{{ .Page.Title }}">
-                <a href="{{ .Page.Permalink }}" title="{{ .Page.Title }} - {{ .Page.Description }}">{{ .Page.Title }}</a>
-              </span>
-              <span class="ms-1">({{ $count }})</span>
-            </div>
-            {{- end }}            
-          {{ end }}
+          {{- $items := where $pages "Draft" "!=" true -}}
+          {{- if $ResourceTypes}}
+            {{- $items = where $items "Params.ResourceType" "in" $ResourceTypes -}}
+          {{- end }}
+          {{- $count := len ($items) -}}
+          {{- if gt $count 0 }}   
+          <div class="col-12 col-xl-6 p-3">
+            {{- partial "components/cards/taxonomy.html" (dict "context" . "subTypes" $ResourceTypes) }}
+          </div>
+            {{end}} {{end}}
         </div>
         <hr />
       </div>

--- a/site/layouts/resources/list.html
+++ b/site/layouts/resources/list.html
@@ -48,6 +48,7 @@
   <div class="row">
     <div class="col-md-2">
       <ul class="list-group">
+        <li class="list-group-item"><a href="/resources">Overview </a></li>
         {{- range $sortedPages }}
           {{- $count :=  len (where .Pages "Draft" "!=" true) }}
           {{- if gt $count 0 }}
@@ -83,6 +84,7 @@
               {{ end }}
               <a href="{{ .RelPermalink }}">{{ .Title }}</a>
             </div>
+            <p>{{ .Description }}</p>
           {{ end }}
         </div>
 
@@ -108,6 +110,7 @@
               {{ end }}
               <a href="{{ .RelPermalink }}">{{ .Title }}</a>
             </div>
+            <p>{{ .Description }}</p>
           {{ end }}
         </div>
         <hr />

--- a/site/static/css/resources.css
+++ b/site/static/css/resources.css
@@ -56,3 +56,16 @@
   color: whitesmoke !important;
   border-color: whitesmoke !important;
 }
+
+
+@media (min-width: 1400px) {
+  .columns-2 {
+    column-count: 2;
+  }
+  .columns-3 {
+    column-count: 3;
+  }
+  .columns-4 {
+    column-count: 4;
+  }
+}


### PR DESCRIPTION
This pull request includes several updates to the layout and styles of the resources section on the site, focusing on improving the display and organization of content. The most important changes include adding a new card layout for taxonomy, updating the main menu resources, and modifying the resources list layout.

Improvements to layout and display:

* [`site/layouts/partials/components/cards/taxonomy.html`](diffhunk://#diff-e07b7e9dedf29e1f1466a4cdd665d79016ec123ebb824b3106e26ed5764cfb98R1-R60): Added a new card layout for displaying taxonomy items, including handling different resource types and their icons.
* [`site/layouts/resources/list.html`](diffhunk://#diff-bc6f06aee1108f242e68d20ec1432ddf5952034d93bf3b5cf1ce1fb3ec973fe1R87): Updated the resources list layout to include descriptions for recent content and categories, and replaced column-based category display with a row-based display. [[1]](diffhunk://#diff-bc6f06aee1108f242e68d20ec1432ddf5952034d93bf3b5cf1ce1fb3ec973fe1R87) [[2]](diffhunk://#diff-bc6f06aee1108f242e68d20ec1432ddf5952034d93bf3b5cf1ce1fb3ec973fe1R113-R131)
* [`site/layouts/partials/main-menu-resources.html`](diffhunk://#diff-fcd316e4fc205e113d6283562c79ea10a14043be8fc11b5adda12d18a1ce49c6R15): Added an overview link to the main menu resources section for better navigation. [[1]](diffhunk://#diff-fcd316e4fc205e113d6283562c79ea10a14043be8fc11b5adda12d18a1ce49c6R15) [[2]](diffhunk://#diff-bc6f06aee1108f242e68d20ec1432ddf5952034d93bf3b5cf1ce1fb3ec973fe1R51)

Code simplification and style updates:

* [`site/layouts/partials/main-menu-resources.html`](diffhunk://#diff-fcd316e4fc205e113d6283562c79ea10a14043be8fc11b5adda12d18a1ce49c6L109-L119): Removed inline styles for column counts to clean up the HTML.
* [`site/static/css/resources.css`](diffhunk://#diff-60c714df6cc7346d535acefb029f2eddde6eeebae9cc1f2af39e4efc1e1fc952R59-R71): Moved column count styles to CSS with media queries for better responsiveness and maintainability.