### PR TITLE
🌐 (baseof.html): conditionally load Google Tag Manager only in non-de…

### DIFF
--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -8,24 +8,28 @@
 <html lang="{{- or site.Language.LanguageCode }}" dir="{{- or site.Language.LanguageDirection `ltr` }}">
   <head>
     <!-- Google Tag Manager -->
-    <script>
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != "dataLayer" ? "&l=" + l : "";
-        j.async = true;
-        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-        f.parentNode.insertBefore(j, f);
-      })(window, document, "script", "dataLayer", "GTM-WRVT65");
-    </script>
+    {{- if ne hugo.Environment "development" }}
+      <script>
+        (function (w, d, s, l, i) {
+          w[l] = w[l] || [];
+          w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+          var f = d.getElementsByTagName(s)[0],
+            j = d.createElement(s),
+            dl = l != "dataLayer" ? "&l=" + l : "";
+          j.async = true;
+          j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+          f.parentNode.insertBefore(j, f);
+        })(window, document, "script", "dataLayer", "GTM-WRVT65");
+      </script>
+    {{- end }}
     <!-- End Google Tag Manager -->
     {{- partial "infrastructure/head.html" . }}
   </head>
   <body data-ndka-environment="{{- hugo.Environment }}" data-ndka-version="v#{GitVersion.SemVer}#">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WRVT65" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    {{- if ne hugo.Environment "development" }}
+      <noscript> <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WRVT65" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    {{- end }}
     <!-- End Google Tag Manager (noscript) -->
     {{- partial "infrastructure/header.html" . }}
 


### PR DESCRIPTION
…velopment environments

The Google Tag Manager script and noscript tags are now wrapped in a conditional statement that checks if the Hugo environment is not set to "development". This change prevents unnecessary loading of Google Tag Manager during development, which can lead to more accurate analytics data by avoiding tracking of development activities. It also improves page load times and reduces resource usage in development environments.