### PR TITLE
♻️ (main-menu-resources.html): refactor resource type icon rendering …

### DIFF
--- a/site/layouts/partials/main-menu-resources.html
+++ b/site/layouts/partials/main-menu-resources.html
@@ -47,6 +47,9 @@
                 {{ range first 20 (where .Site.RegularPages.ByWeight "Type" "resources") }}
                   <div class=" text-truncate" title="{{ .Title }} - {{ .Description }}{{ if gt .Date (now) }}&#10;&#10;Scheduled: {{ .Date.Format "2006-01-02 15:04" }}{{ end }}">
                     {{- partial "components/resources/resource-icon.html" . }}
+                    {{ if .Draft }}
+                      <i class="fa-brands fa-firstdraft"></i>
+                    {{ end }}
                     {{ if gt .Date (now) }}
                       <i class="fa-regular fa-flux-capacitor"></i>
                     {{ end }}

--- a/site/layouts/partials/main-menu-resources.html
+++ b/site/layouts/partials/main-menu-resources.html
@@ -27,15 +27,7 @@
               <div class="columns-2">
                 {{ range first 20 (sort (where .Site.RegularPages "Type" "resources") "Date" "desc") }}
                   <div class=" text-truncate" title="{{ .Title }} - {{ .Description }} {{ if gt .Date (now) }}&#10;&#10;Scheduled: {{ .Date.Format "2006-01-02 15:04" }}{{ end }}">
-                    {{ if eq .Params.ResourceType "videos" }}
-                      <i class="fa-solid fa-video"></i>
-                    {{ else if eq .Params.ResourceType "blog" }}
-                      <i class="fa-solid fa-newspaper"></i>
-                    {{ else if eq .Params.ResourceType "newsletters" }}
-                      <i class="fa-solid fa-envelope-open-text"></i>
-                    {{ else }}
-                      {{ .Params.ResourceType }}
-                    {{ end }}
+                    {{- partial "components/resources/resource-icon.html" . }}
                     {{ if .Draft }}
                       <i class="fa-brands fa-firstdraft"></i>
                     {{ end }}
@@ -54,20 +46,7 @@
               <div class="columns-2">
                 {{ range first 20 (where .Site.RegularPages.ByWeight "Type" "resources") }}
                   <div class=" text-truncate" title="{{ .Title }} - {{ .Description }}{{ if gt .Date (now) }}&#10;&#10;Scheduled: {{ .Date.Format "2006-01-02 15:04" }}{{ end }}">
-                    {{ if eq .Params.ResourceType "videos" }}
-                      <i class="fa-solid fa-video"></i>
-                    {{ else if eq .Params.ResourceType "blog" }}
-                      <i class="fa-solid fa-newspaper"></i>
-                    {{ else if eq .Params.ResourceType "newsletters" }}
-                      <i class="fa-solid fa-envelope-open-text"></i>
-                    {{ else if eq .Params.ResourceType "podcasts" }}
-                      <i class="fa-solid fa-podcast"></i>
-                    {{ else }}
-                      {{ .Params.ResourceType }}
-                    {{ end }}
-                    {{ if .Draft }}
-                      <i class="fa-brands fa-firstdraft"></i>
-                    {{ end }}
+                    {{- partial "components/resources/resource-icon.html" . }}
                     {{ if gt .Date (now) }}
                       <i class="fa-regular fa-flux-capacitor"></i>
                     {{ end }}


### PR DESCRIPTION
…to use a partial template

The resource type icon rendering logic is moved to a partial template to improve code maintainability and reusability. This change reduces duplication and centralizes the icon rendering logic, making it easier to update or extend in the future. By using a partial, the code becomes more modular and easier to manage.