### PR TITLE
Improve display

### DIFF
--- a/site/layouts/partials/main-menu-resources.html
+++ b/site/layouts/partials/main-menu-resources.html
@@ -38,7 +38,6 @@
                   </div>
                 {{ end }}
               </div>
-
               <hr />
             </div>
             <div class="m-1">

--- a/site/layouts/partials/main-menu-resources.html
+++ b/site/layouts/partials/main-menu-resources.html
@@ -25,7 +25,7 @@
             <div class="m-1">
               <h5>Recent</h5>
               <div class="columns-2">
-                {{ range first 20 (sort (where .Site.RegularPages "Type" "resources") "Date" "desc") }}
+                {{ range first 5 (sort (where .Site.RegularPages "Type" "resources") "Date" "desc") }}
                   <div class=" text-truncate" title="{{ .Title }} - {{ .Description }} {{ if gt .Date (now) }}&#10;&#10;Scheduled: {{ .Date.Format "2006-01-02 15:04" }}{{ end }}">
                     {{- partial "components/resources/resource-icon.html" . }}
                     {{ if .Draft }}
@@ -38,12 +38,13 @@
                   </div>
                 {{ end }}
               </div>
+              <a href="/resources/" class="btn btn-sm btn-outline-secondary">See all</a>
               <hr />
             </div>
             <div class="m-1">
               <h5>Important</h5>
               <div class="columns-2">
-                {{ range first 20 (where .Site.RegularPages.ByWeight "Type" "resources") }}
+                {{ range first 5 (where .Site.RegularPages.ByWeight "Type" "resources") }}
                   <div class=" text-truncate" title="{{ .Title }} - {{ .Description }}{{ if gt .Date (now) }}&#10;&#10;Scheduled: {{ .Date.Format "2006-01-02 15:04" }}{{ end }}">
                     {{- partial "components/resources/resource-icon.html" . }}
                     {{ if .Draft }}
@@ -56,21 +57,7 @@
                   </div>
                 {{ end }}
               </div>
-              <hr />
-            </div>
-            <div class="m-1 small">
-              <h5>Concepts</h5>
-              <div class="columns-3">
-                {{ range $category, $pages := .Site.Taxonomies.concepts }}
-                  <div class="d-flex align-items-center">
-                    <span class="text-truncate d-inline-block" style="max-width: 100%;" title="{{ .Page.Title }}">
-                      <a href="{{ .Page.Permalink }}" title="{{ .Page.Title }} - {{ .Page.Description }}">{{ .Page.Title }}</a>
-                    </span>
-                    {{- $count :=  len (where $pages "Draft" "!=" true) }}
-                    <span class="ms-1">({{ $count }})</span>
-                  </div>
-                {{ end }}
-              </div>
+              <a href="/resources/" class="btn btn-sm btn-outline-secondary">See all</a>
               <hr />
             </div>
             <div class="m-1 small">

--- a/site/layouts/partials/main-menu-resources.html
+++ b/site/layouts/partials/main-menu-resources.html
@@ -25,14 +25,12 @@
             <div class="m-1">
               <h5>Recent</h5>
               <div class="columns-2">
-                {{ range first 5 (sort (where .Site.RegularPages "Type" "resources") "Date" "desc") }}
-                  <div class=" text-truncate" title="{{ .Title }} - {{ .Description }} {{ if gt .Date (now) }}&#10;&#10;Scheduled: {{ .Date.Format "2006-01-02 15:04" }}{{ end }}">
+                {{ $published := where (where .Site.RegularPages "Type" "resources") "Date" "le" now }}
+                {{ range first 6 (sort $published "Date" "desc") }}
+                  <div class="text-truncate" title="{{ .Title }} - {{ .Description }}">
                     {{- partial "components/resources/resource-icon.html" . }}
                     {{ if .Draft }}
                       <i class="fa-brands fa-firstdraft"></i>
-                    {{ end }}
-                    {{ if gt .Date (now) }}
-                      <i class="fa-regular fa-flux-capacitor"></i>
                     {{ end }}
                     <a href="{{ .RelPermalink }}">{{ .Title }}</a>
                   </div>
@@ -44,7 +42,8 @@
             <div class="m-1">
               <h5>Important</h5>
               <div class="columns-2">
-                {{ range first 5 (where .Site.RegularPages.ByWeight "Type" "resources") }}
+                {{ $publishedByWeight := where (where .Site.RegularPages.ByWeight "Type" "resources") "Date" "le" now }}
+                {{ range first 6 $publishedByWeight }}
                   <div class=" text-truncate" title="{{ .Title }} - {{ .Description }}{{ if gt .Date (now) }}&#10;&#10;Scheduled: {{ .Date.Format "2006-01-02 15:04" }}{{ end }}">
                     {{- partial "components/resources/resource-icon.html" . }}
                     {{ if .Draft }}
@@ -62,7 +61,7 @@
             </div>
             <div class="m-1 small">
               <h5>Categories</h5>
-              <div class="columns-3">
+              <div class="columns-4">
                 {{ range $category, $pages := .Site.Taxonomies.categories }}
                   <div class="d-flex align-items-center">
                     <span class="text-truncate d-inline-block" style="max-width: 100%;" title="{{ .Page.Title }}">
@@ -90,7 +89,7 @@
                     <span class="text-truncate d-inline-block" style="max-width: 100%;" title="{{ .name }}">
                       <a href="{{ .page.Permalink }}" title="{{ .page.Title }} - {{ .page.Description }}">{{ .page.Title }}</a>
                     </span>
-                    <span class="ms-1">({{ .count }}){{- if ne hugo.Environment "production" }}[W:{{ .page.Weight }}]{{ end }}</span>
+                    <span class="ms-1">({{ .count }})</span>
                   </div>
                 {{ end }}
                 <br />

--- a/site/layouts/resources/list.html
+++ b/site/layouts/resources/list.html
@@ -94,7 +94,7 @@
         <div class="m-1">
           <h5>Most recent content</h5>
           <div class="columns-2">
-            {{ $recent := first 10 (sort $resources "Date" "desc") }}
+            {{ $recent := first 20 (sort $resources "Date" "desc") }}
 
             {{ range $recent }}
               <div class=" text-truncate" title="{{ .Title }} - {{ .Description }}{{ if gt .Date (now) }}&#10;&#10;Scheduled: {{ .Date.Format "2006-01-02 15:04" }}{{ end }}">
@@ -107,7 +107,7 @@
                 {{ end }}
                 <a href="{{ .RelPermalink }}">{{ .Title }}</a>
               </div>
-              <p>{{ .Description }}</p>
+              {{/*  <p>{{ .Description }}</p>  */}}
             {{ end }}
           </div>
 
@@ -116,7 +116,7 @@
         <div class="m-1">
           <h5>On Engineering Excelence & Technical Leadership</h5>
           <div class="columns-2">
-            {{ range first 10 $resources.ByWeight }}
+            {{ range first 20 $resources.ByWeight }}
               <div class=" text-truncate" title="{{ .Title }} - {{ .Description }}">
                 {{- partial "components/resources/resource-icon.html" . }}
                 {{ if .Draft }}
@@ -127,7 +127,28 @@
                 {{ end }}
                 <a href="{{ .RelPermalink }}">{{ .Title }}</a>
               </div>
-              <p>{{ .Description }}</p>
+              {{/*  <p>{{ .Description }}</p>  */}}
+            {{ end }}
+          </div>
+          <hr />
+        </div>
+         <div class="m-1 small">
+          <h5>Concepts</h5>`
+          <div class="columns-4">
+            {{ range $category, $pages := .Site.Taxonomies.concepts }}
+              {{- $items := where $pages "Draft" "!=" true -}}
+              {{- if $ResourceTypes }}
+                {{- $items = where $items "Params.ResourceType" $ResourceTypes -}}
+              {{- end }}
+              {{- $count := len ($items) -}}
+              {{- if gt $count 0 }}
+                <div class="d-flex align-items-center">
+                  <span class="text-truncate d-inline-block" style="max-width: 100%;" title="{{ .Page.Title }}">
+                    <a href="{{ .Page.Permalink }}" title="{{ .Page.Title }} - {{ .Page.Description }}">{{ .Page.Title }}</a>
+                  </span>
+                  <span class="ms-1">({{ $count }})</span>
+                </div>
+              {{- end }}
             {{ end }}
           </div>
           <hr />

--- a/site/layouts/resources/list.html
+++ b/site/layouts/resources/list.html
@@ -57,16 +57,11 @@
       <div class="col-md-10">
         {{- if ne hugo.Environment "production" }}
           <div class="m-1">
-            {{ $resources := sort (where .Site.RegularPages "Type" "resources") "Date" "desc" }}
-            {{ $.Scratch.Set "futureResources" (slice) }}
-
-            {{ range $resources }}
-              {{ if .Date.After now }}
-                {{ $.Scratch.Add "futureResources" (slice .) }}
-              {{ end }}
+            {{ $futureResources := where (where .Site.RegularPages "Type" "resources") "Date" "ge" now }}
+            {{ $futureResources := sort $futureResources "Date" "desc"}}
+            {{ if .Params.ResourceTypes }}
+              {{ $futureResources = where $futureResources "Params.ResourceType" .Params.ResourceTypes }}
             {{ end }}
-
-            {{ $futureResources := $.Scratch.Get "futureResources" }}
             <h5>Future ({{ len $futureResources }})</h5>
             <div class="columns-2">
               {{ range $futureResources }}
@@ -87,7 +82,8 @@
             <hr />
           </div>
         {{- end }}
-        {{ $resources := where .Site.RegularPages "Type" "resources" }}
+        
+        {{ $resources := where (where .Site.RegularPages "Type" "resources") "Date" "le" now }}
         {{ if .Params.ResourceTypes }}
           {{ $resources = where $resources "Params.ResourceType" .Params.ResourceTypes }}
         {{ end }}
@@ -133,7 +129,7 @@
           <hr />
         </div>
          <div class="m-1 small">
-          <h5>Concepts</h5>`
+          <h5>Concepts</h5>
           <div class="columns-4">
             {{ range $category, $pages := .Site.Taxonomies.concepts }}
               {{- $items := where $pages "Draft" "!=" true -}}

--- a/site/layouts/resources/list.html
+++ b/site/layouts/resources/list.html
@@ -55,6 +55,38 @@
         </ul>
       </div>
       <div class="col-md-10">
+        {{- if ne hugo.Environment "production" }}
+          <div class="m-1">
+            {{ $resources := sort (where .Site.RegularPages "Type" "resources") "Date" "desc" }}
+            {{ $.Scratch.Set "futureResources" (slice) }}
+
+            {{ range $resources }}
+              {{ if .Date.After now }}
+                {{ $.Scratch.Add "futureResources" (slice .) }}
+              {{ end }}
+            {{ end }}
+
+            {{ $futureResources := $.Scratch.Get "futureResources" }}
+            <h5>Future ({{ len $futureResources }})</h5>
+            <div class="columns-2">
+              {{ range $futureResources }}
+                {{ $duration := .Date.Sub now }}
+                {{ $days := math.Floor (div $duration.Hours 24) }}
+                <div class="text-truncate" title="{{ .Title }} - {{ .Description }}&#10;&#10;Scheduled: {{ .Date.Format "2006-01-02 15:04" }} (in {{ $days }} days)">
+                  {{- partial "components/resources/resource-icon.html" . }}
+                  {{ if .Draft }}
+                    <i class="fa-brands fa-firstdraft"></i>
+                  {{ end }}
+                  <i class="fa-regular fa-flux-capacitor"></i>
+                  <span title="in {{ $days }} days">[{{ $days }}]</span>
+                  <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+                </div>
+              {{ end }}
+            </div>
+
+            <hr />
+          </div>
+        {{- end }}
         {{ $resources := where .Site.RegularPages "Type" "resources" }}
         {{ if .Params.ResourceTypes }}
           {{ $resources = where $resources "Params.ResourceType" .Params.ResourceTypes }}


### PR DESCRIPTION
✨ (resources): add display for future resources in non-production environments

Remove unnecessary whitespace in main-menu-resources.html for cleaner code. Introduce a new feature in resources/list.html to display future resources when not in production. This helps developers and content managers preview upcoming resources, ensuring they are aware of scheduled content and can make necessary adjustments before it goes live. The feature includes a count of future resources and displays the number of days until each resource is scheduled to be published.