### PR TITLE
🐛 (ClassificationHelpers.ps1): correct typo in 'reasoning_summary' key

### DIFF
--- a/.powershell/_includes/ClassificationHelpers.ps1
+++ b/.powershell/_includes/ClassificationHelpers.ps1
@@ -637,7 +637,7 @@ function Get-ConfidenceFromAIResponse {
             "ai_penalty_details"   = if ($AIResponse.PSObject.Properties["penalty_details"]) { $AIResponse.penalty_details } else { $null }
             "final_score"          = $finalScore
             "reasoning"            = $AIResponse.reasoning
-            "reasoning_summery"    = if ($AIResponse.PSObject.Properties["reasoning_summery"]) { $AIResponse.reasoning_summery } else { $null }
+            "reasoning_summary"    = if ($AIResponse.PSObject.Properties["reasoning_summary"]) { $AIResponse.reasoning_summary } else { $null }
             "level"                = Get-ComputedLevel -confidence $finalScore
         }
     }


### PR DESCRIPTION
♻️ (PromptManager.ps1): improve placeholder replacement logic with regex and case-insensitive lookup

Corrects a typo in the 'reasoning_summary' key to ensure consistency and prevent potential errors when accessing this property. Refactors the placeholder replacement logic in PromptManager.ps1 to use regex for matching patterns and implements a case-insensitive lookup for parameter keys. This enhances the robustness of the prompt generation by ensuring all placeholders are correctly replaced, even if there are variations in case.