### PR TITLE
🐛 (signal.html): correct parameter name from platform_signal to platform_signals

### DIFF
--- a/site/layouts/resources/signal.html
+++ b/site/layouts/resources/signal.html
@@ -13,7 +13,7 @@
   <section class="container my-5" style="max-width: 700px !important">
     {{- .Content }}
     <ul class="nav nav-tabs" id="myTab" role="tablist">
-      {{ with .Params.platform_signal }}
+      {{ with .Params.platform_signals }}
         {{ range $index, $item := . }}
           <li class="nav-item" role="presentation">
             <button class="nav-link {{ if eq $index 0 }}active{{ end }}" id="signals-tab" data-bs-toggle="tab" data-bs-target="#{{ .platform }}" type="button" role="tab" aria-controls="signals" aria-selected="{{ if eq $index 0 }}true{{ else }}false{{ end }}">{{ .platform }}</button>


### PR DESCRIPTION
The parameter name was incorrect, causing issues in rendering the platform signals. Changing it from `platform_signal` to `platform_signals` aligns with the expected data structure and ensures that the signals are correctly iterated and displayed in the UI.