### PR TITLE
📝 (content): add new resource article on Heathrow power failure

### DIFF
--- a/site/content/resources/signals/2025-05-15-when-heathrow-went-down-they-blamed-the-power-supplier/index.md
+++ b/site/content/resources/signals/2025-05-15-when-heathrow-went-down-they-blamed-the-power-supplier/index.md
@@ -1,0 +1,32 @@
+---
+title: When Heathrow went down, they blamed the power supplier."
+date: 2025-05-15T15:30:30+01:00
+slug: when-heathrow-went-down-they-blamed-the-power-supplier
+draft: true
+source: LinkedIn
+platform_signals:
+- platform: LinkedIn
+  post_url: https://www.linkedin.com/feed/update/urn:li:share:7328803975921569792
+  post_id: "7328803975921569792"
+  post_date: 2025-05-15T14:30:30Z
+  performance:
+    impressions: 0
+    members_reached: 0
+    reactions: 0
+    comments: 0
+    reposts: 0
+
+---
+When Heathrow went down, they blamed the power supplier.
+
+A fire at one substation, they said, caused the disruption. Convenient story. But it wasn't true.
+
+Heathrow gets power from three independent substations. Any one of them could run the airport solo. The real failure? Their internal "resilience" system kicked in when it saw a fluctuation—not a loss. And in its attempt to “protect” the infrastructure, it shut the entire thing down.
+
+It took all day to reboot. Not because power was unavailable, but because their disaster recovery system was too sensitive to survive a real incident.
+
+That’s what happens when resilience is theatre. Flashy systems. Fancy architecture. And no one asking the hard question: what actually happens when things get messy?
+
+If you haven’t tested for chaos, you’ve only prepared for comfort.
+
+Don’t confuse infrastructure spend with resilience. Resilience is what happens when your assumptions fail.

--- a/site/layouts/partials/main-menu-resources.html
+++ b/site/layouts/partials/main-menu-resources.html
@@ -26,6 +26,7 @@
               <h5>Recent</h5>
               <div class="columns-2">
                 {{ $published := where (where .Site.RegularPages "Type" "resources") "Date" "le" now }}
+                {{ $published = where $published "Params.ResourceType" "ne" "signals" }}
                 {{ range first 6 (sort $published "Date" "desc") }}
                   <div class="text-truncate" title="{{ .Title }} - {{ .Description }}">
                     {{- partial "components/resources/resource-icon.html" . }}
@@ -43,6 +44,7 @@
               <h5>Important</h5>
               <div class="columns-2">
                 {{ $publishedByWeight := where (where .Site.RegularPages.ByWeight "Type" "resources") "Date" "le" now }}
+                {{ $publishedByWeight = where $publishedByWeight "Params.ResourceType" "ne" "signals" }}
                 {{ range first 6 $publishedByWeight }}
                   <div class=" text-truncate" title="{{ .Title }} - {{ .Description }}{{ if gt .Date (now) }}&#10;&#10;Scheduled: {{ .Date.Format "2006-01-02 15:04" }}{{ end }}">
                     {{- partial "components/resources/resource-icon.html" . }}


### PR DESCRIPTION
🔧 (layout): update main menu to exclude 'signals' from recent and important resources

Add a new article discussing the Heathrow power failure incident, highlighting the importance of true resilience over superficial infrastructure investments. The main menu layout is updated to exclude resources of type 'signals' from appearing in the 'Recent' and 'Important' sections, ensuring that only relevant content is displayed to users. This change helps maintain focus on more critical resources and improves user experience by filtering out less significant content.