### PR TITLE
Fix for SameAs

### DIFF
--- a/site/layouts/partials/infrastructure/seo.html
+++ b/site/layouts/partials/infrastructure/seo.html
@@ -100,7 +100,7 @@
           }
           {{- end }}
           {{- end }}
-        ]
+        ],
         "sameAs": [
           {{- $now := now -}}
           {{- with .Params.platform_signals }}


### PR DESCRIPTION
📝 (seo.html): fix JSON syntax by adding a missing comma

A missing comma in the JSON structure is corrected to ensure valid JSON syntax. This change prevents potential parsing errors and ensures the SEO configuration is correctly interpreted by search engines and other tools.