### PR TITLE
Feedback

### DIFF
--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -20,7 +20,8 @@ params:
   author: "Martin Hinshelwood"
   og_image: "/images/og-image.jpg" # URL to the default Open Graph image
   twitter_handle: "@nkdagility" # Your Twitter handle for Twitter cards
-  editURL: "https://github.com/nkdAgility/nkdagility.com/edit/main/site/content/" # URL to edit content on GitHub
+  githubRepo: "https://github.com/nkdAgility/nkdagility.com" # URL to edit content on GitHub
+  githubContentDir: "site/content" # Directory in the GitHub repo where content is stored
 
 pagination:
   pagerSize: 30

--- a/site/layouts/partials/components/feedback-dropdown.html
+++ b/site/layouts/partials/components/feedback-dropdown.html
@@ -1,0 +1,10 @@
+<div class="dropdown {{ if eq hugo.Environment "production" }}d-none{{ end }}">
+  <button type="button" class="btn btn-sm btn-outline-secondary text-nowrap" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-xl-inline">Collaborate </span><i class="fa-regular fa-message-pen"></i></button>
+  <div class="dropdown-menu dropdown-menu-end p-3">
+    <a class="btn btn-outline-info btn-sm w-100 mb-2" href="#comments" title="Discuss on Github"><i class="fa-regular fa-comment"></i> Feedback </a>
+    <a class="btn btn-outline-info btn-sm w-100 mb-2" href="{{ site.Params.githubRepo }}/blob/main/{{ site.Params.githubContentDir }}/{{ .Path }}/index.md" target="_blank" rel="noopener noreferrer"> <i class="fa-solid fa-expand"></i> View on Github </a>
+    <a class="btn btn-outline-info btn-sm w-100 mb-2" href="{{ site.Params.githubRepo }}/edit/main/{{ site.Params.githubContentDir }}/{{ .Path }}/index.md" target="_blank" rel="noopener noreferrer"> <i class="fa-solid fa-code-branch"></i> Edit on Github </a>
+    <hr />
+    <a class="btn btn-outline-info btn-sm w-100 mb-2" href="{{ site.Params.githubRepo }}/blob/main/{{ site.Params.githubContentDir }}/{{ .Path }}/data.index.classifications.json" target="_blank" rel="noopener noreferrer"> <i class="fa-solid fa-tags"></i> Classifications </a>
+  </div>
+</div>

--- a/site/layouts/partials/components/resources/share-bar.html
+++ b/site/layouts/partials/components/resources/share-bar.html
@@ -8,19 +8,15 @@
       <a class="btn btn-sm  btn-outline-secondary align-items-center" href="#learnMore" title="Jump to more posts on this topic"> <span class="d-none d-xl-inline"> Learn More </span> <i class="fa-light fa-list"></i> </a>
     {{ end }}
     <a class="btn btn-sm  btn-outline-secondary align-items-center" href="#comments" title="Join the conversation"> <span class="d-none d-xl-inline">Comments</span> <i class="fa-regular fa-comment"></i> </a>
+    {{- partial "components/feedback-dropdown.html" . }}
     {{- partial "components/language-dropdown.html" . }}
+
   </div>
 
   <!-- Right-aligned 'Share' dropdown button -->
   <div class="d-inline-flex gap-2">
     {{- partial "components/share-dropdown.html" . }}
-    {{- if ne hugo.Environment "production" }}
-      <div class="dropdown {{ if eq hugo.Environment "production" }}d-none{{ end }}">
-        <button type="button" class="btn btn-sm btn-outline-secondary text-nowrap" data-bs-toggle="dropdown" aria-expanded="false"><span class="d-none d-xl-inline">Edit </span><i class="fa-light fa-pen-to-square"></i></button>
-        <div class="dropdown-menu dropdown-menu-end p-3"></div>
-      </div>
-      {{- partial "components/admin-dropdown.html" . }}
-    {{ end }}
+    {{- partial "components/admin-dropdown.html" . }}
     <a href="#" class="btn btn-sm btn-outline-secondary text-nowrap" title="Sign up for more posts" data-bs-toggle="modal" data-bs-target="#followModal"><span class="d-none d-xl-inline">Subscribe </span><i class="fa-regular fa-cowbell-circle-plus"></i></a>
   </div>
 </div>


### PR DESCRIPTION
✨🔧 (hugo.yaml, feedback-dropdown.html): enhance GitHub integration and add feedback dropdown

Update `hugo.yaml` to separate GitHub repository URL and content directory, improving configuration clarity. Introduce a new feedback dropdown component in `feedback-dropdown.html` to facilitate user interaction and content collaboration. This component allows users to view, edit, and discuss content directly on GitHub, enhancing user engagement and content management. The feedback dropdown is integrated into the share bar, replacing the previous edit button, and is hidden in production to maintain a clean UI.