### PR TITLE
Fix for Blog + Refactor

### DIFF
--- a/site/content/resources/blog/_index.md
+++ b/site/content/resources/blog/_index.md
@@ -6,8 +6,6 @@ url: "/resources/blog/"
 aliases:
   - /blog/
 layout: bloglist
-resourceTypes:
-  - blog
 resourceType: blog
 sitemap:
   filename: sitemap.xml

--- a/site/content/resources/case-studies/_index.md
+++ b/site/content/resources/case-studies/_index.md
@@ -3,7 +3,6 @@ title: "Agentic Agility: Case Studies"
 shorttitle: "Case Studies"
 url: "/resources/case-studies/"
 layout: "section" # Hugo will use section.html to render the list of pages
-resourceTypes: case-studies
 resourceType: case-studies
 ---
 

--- a/site/content/resources/engineering-notes/_index.md
+++ b/site/content/resources/engineering-notes/_index.md
@@ -4,7 +4,6 @@ description: Pragmatic guidance and step-by-step approaches for implementing adv
 shorttitle: "Engineering Notes"
 url: "/resources/engineering-notes/"
 layout: bloglist
-resourceTypes: engineering-notes
 resourceType: engineering-notes
 sitemap:
   filename: sitemap.xml

--- a/site/content/resources/guides/_index.md
+++ b/site/content/resources/guides/_index.md
@@ -6,7 +6,6 @@ weight: 1
 aliases:
   - /learn/agile-delivery-kit/guides/
 layout: "section" # Hugo will use section.html to render the list of pages
-resourceTypes: guides
 resourceType: guides
 trustpilot: false
 headline:

--- a/site/content/resources/learning-series/_index.md
+++ b/site/content/resources/learning-series/_index.md
@@ -3,7 +3,6 @@ title: "Agentic Agility: Learning Series"
 shorttitle: "Learning Series"
 url: "/resources/learning-series/"
 layout: "section" # Hugo will use section.html to render the list of pages
-resourceTypes: learning-series
 resourceType: learning-series
 ---
 

--- a/site/content/resources/newsletters/_index.md
+++ b/site/content/resources/newsletters/_index.md
@@ -3,7 +3,6 @@ title: "Agentic Agility: Newsletters"
 shorttitle: "Newsletters"
 url: "/resources/newsletters/"
 layout: "section" # Hugo will use section.html to render the list of pages
-resourceTypes: newsletters
 resourceType: newsletters
 aliases:
   - /newsletters/

--- a/site/content/resources/podcast/_index.md
+++ b/site/content/resources/podcast/_index.md
@@ -3,7 +3,6 @@ title: "Agentic Agility: Podcasts"
 shorttitle: "Podcasts"
 url: "/resources/podcasts/"
 layout: "section" # Hugo will use section.html to render the list of pages
-resourceTypes: podcast
 resourceType: podcast
 ---
 

--- a/site/content/resources/principles/_index.md
+++ b/site/content/resources/principles/_index.md
@@ -4,7 +4,6 @@ shorttitle: "Principles"
 description: Our principles are the foundation of our work. They guide our decisions, actions, and interactions. They are the essence of who we are and what we stand for. They are the reason we do what we do.
 draft: false
 layout: "section" # Hugo will use section.html to render the list of pages
-resourceTypes: principals
 resourceType: principals
 aliases:
   - /learn/agile-delivery-kit/first-principals/

--- a/site/content/resources/recipes/_index.md
+++ b/site/content/resources/recipes/_index.md
@@ -3,7 +3,6 @@ title: "Agentic Agility: Recipes"
 shorttitle: "Recipes"
 layout: "section" # Hugo will use section.html to render the list of pages
 trustpilot: false
-resourceTypes: recipes
 resourceType: recipes
 headline:
   cards: []

--- a/site/content/resources/signals/_index.md
+++ b/site/content/resources/signals/_index.md
@@ -4,7 +4,6 @@ description: Bite-sized, timely social updates highlighting emerging trends, ins
 shorttitle: "Signals"
 url: "/resources/signals/"
 layout: "section" # Hugo will use section.html to render the list of pages
-resourceTypes: signals
 resourceType: signals
 trustpilot: false
 headline:

--- a/site/content/resources/videos/_index.md
+++ b/site/content/resources/videos/_index.md
@@ -4,7 +4,6 @@ description: "Dive into concise, practical insights on Agile, Scrum, and DevOps.
 shorttitle: "Videos"
 url: "/resources/videos/"
 layout: "section" # Hugo will use section.html to render the list of pages
-resourceTypes: videos
 resourceType: videos
 trustpilot: false
 headline:

--- a/site/content/resources/workshops/_index.md
+++ b/site/content/resources/workshops/_index.md
@@ -3,7 +3,6 @@ title: "Agentic Agility: Workshops"
 shorttitle: "Workshops"
 url: "/resources/workshops/"
 layout: "section" # Hugo will use section.html to render the list of pages
-resourceTypes: workshops
 resourceType: workshops
 ---
 

--- a/site/layouts/resources/list.html
+++ b/site/layouts/resources/list.html
@@ -32,7 +32,7 @@
             {{ $futureResources := where (where .Site.RegularPages "Type" "resources") "Date" "ge" now }}
             {{ $futureResources := sort $futureResources "Date" "desc"}}
             {{ if .Params.ResourceTypes }}
-              {{ $futureResources = where $futureResources "Params.ResourceType" .Params.ResourceTypes }}
+              {{ $futureResources = where $futureResources "Params.ResourceType" .Params.ResourceType }}
             {{ end }}
             <h5>Future ({{ len $futureResources }})</h5>
             <div class="columns-2">
@@ -56,7 +56,7 @@
          {{ $resources = where $resources "Params.ResourceType" "ne" "signals" }}
         {{ end }}
         {{ if .Params.ResourceTypes }}
-          {{ $resources = where $resources "Params.ResourceType" .Params.ResourceTypes }}
+          {{ $resources = where $resources "Params.ResourceType" .Params.ResourceType }}
         {{ end }}
         <div class="m-1">
           <h5>Most recent content</h5>


### PR DESCRIPTION
This pull request refactors the `resourceTypes` parameter across multiple content files and updates its usage in the layout logic. The changes standardize the use of `resourceType` instead of `resourceTypes` and ensure consistency in filtering logic within the layout templates.

### Standardization of `resourceType` Parameter:

* **Content Files:** Replaced `resourceTypes` with `resourceType` in metadata across several resource content files, such as `blog`, `case-studies`, `engineering-notes`, `guides`, and others. This change improves consistency and simplifies metadata definitions. [[1]](diffhunk://#diff-44e84645674789b42f6990de35a33a89434be20601c9d9bdcaafdf8ea9e21b9bL9-L10) [[2]](diffhunk://#diff-b8636106793930a25e66e29d73620ce9e5994cfb0bce00c2b0526d2ee8c91373L6) [[3]](diffhunk://#diff-aaaeec0628159a44fc166c55e5767cc9f1ab1b428fab495fdea9f2f33d55e7dcL7) [[4]](diffhunk://#diff-a4a1aa2516315e8f3c6c0867bafa5418c6034b9fb0d53977f97cc81685d9aadeL9) [[5]](diffhunk://#diff-2c8f56556d35692fda6aa13ca4b6d349d6ed6e736205225a81327e13388f0c1fL6) [[6]](diffhunk://#diff-93f8232dc7bea120a5f492addc438a5548f6d950d8b5e0914eb587be1b13caaeL6) [[7]](diffhunk://#diff-fbb13a705bfe3b6f5b1283371e2e19e0a496789a269c63b45910698ee8e97187L6) [[8]](diffhunk://#diff-d3af1ea6833bf31ca4c8069c7abdc724ccf75ac52a3fb6b3b8746af3b22fceffL7) [[9]](diffhunk://#diff-f616a59df6bcbca07ef02bf95d218e3d70fd7c45a6297a554d8214694342d12aL6) [[10]](diffhunk://#diff-52f93452982bb5e28089543a4005c6077cfb1527686b0c37483b1254c1ecaf0bL7) [[11]](diffhunk://#diff-3a9a0f5de882d6c384afb8e961fb25fe74ada562ecd9e6e1d719f1d354807d08L7) [[12]](diffhunk://#diff-3b88125707876a905446e3221ba583b58111e431909c63a5b5aa3d857671dcb0L6)

### Updates to Layout Logic:

* **`site/layouts/resources/list.html`:** Updated filtering logic to use `Params.ResourceType` instead of `Params.ResourceTypes` for both future resources and most recent content sections. This aligns the layout logic with the standardized metadata changes. [[1]](diffhunk://#diff-bc6f06aee1108f242e68d20ec1432ddf5952034d93bf3b5cf1ce1fb3ec973fe1L35-R35) [[2]](diffhunk://#diff-bc6f06aee1108f242e68d20ec1432ddf5952034d93bf3b5cf1ce1fb3ec973fe1L59-R59)