### PR TITLE
Update to fix termly

### DIFF
--- a/site/layouts/baseof.html
+++ b/site/layouts/baseof.html
@@ -8,6 +8,7 @@
 {{ end }}
 <html lang="{{- or site.Language.LanguageCode }}" dir="{{- or site.Language.LanguageDirection `ltr` }}">
   <head>
+    <script src="https://app.termly.io/resource-blocker/8bfd9df8-10f3-48d6-8543-802e916c4a5c?autoBlock=on"></script>
     <!-- Place this as the very first thing in your <head>, before any CSS -->
     <script src="{{- "js/appearance-switcher-preset.js" | relURL }}"></script>
     <!-- Google Tag Manager -->


### PR DESCRIPTION
This pull request introduces a small but important change to the `site/layouts/baseof.html` file. The change adds a script for Termly's resource blocker to enhance compliance with privacy regulations.

* [`site/layouts/baseof.html`](diffhunk://#diff-3bbbfaaa4954ec5b4cfed885c7412ff68657f714498abd64d296e82fae9faa56R11): Added a Termly resource blocker script (`https://app.termly.io/resource-blocker/8bfd9df8-10f3-48d6-8543-802e916c4a5c?autoBlock=on`) to the `<head>` section of the HTML, ensuring it loads before any CSS.