### PR TITLE
Update environment checks for script inclusion in baseof.html

### DIFF
--- a/site/layouts/baseof.html
+++ b/site/layouts/baseof.html
@@ -31,7 +31,7 @@
 
     {{- partial "infrastructure/head.html" . }}
   </head>
-  <body data-ndka-environment="{{- hugo.Environment }}" data-ndka-version="v#{GitVersion.SemVer}#">
+  <body data-ndka-environment="{{- hugo.Environment }}" data-ndka-version="v#{GitVersion.SemVer}#" data-nkda-renderGTM=" {{- if or (eq hugo.Environment "preview") (eq hugo.Environment "production") }}true{{ else }}false{{- end }}">
     {{- if or (eq hugo.Environment "preview") (eq hugo.Environment "production") }}
       <!-- Google Tag Manager (noscript) -->
       <noscript> <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WRVT65" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/site/layouts/baseof.html
+++ b/site/layouts/baseof.html
@@ -8,7 +8,7 @@
 {{ end }}
 <html lang="{{- or site.Language.LanguageCode }}" dir="{{- or site.Language.LanguageDirection `ltr` }}">
   <head>
-    {{- if ne hugo.Environment "development" }}
+    {{- if or (eq hugo.Environment "preview") (eq hugo.Environment "production") }}
       <!-- termly.io-->
       <script src="https://app.termly.io/resource-blocker/8bfd9df8-10f3-48d6-8543-802e916c4a5c?autoBlock=on"></script>
       <!-- Google Tag Manager -->
@@ -32,7 +32,7 @@
     {{- partial "infrastructure/head.html" . }}
   </head>
   <body data-ndka-environment="{{- hugo.Environment }}" data-ndka-version="v#{GitVersion.SemVer}#">
-    {{- if ne hugo.Environment "development" }}
+    {{- if or (eq hugo.Environment "preview") (eq hugo.Environment "production") }}
       <!-- Google Tag Manager (noscript) -->
       <noscript> <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WRVT65" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <!-- End Google Tag Manager (noscript) -->


### PR DESCRIPTION
This pull request updates the conditional logic in the `site/layouts/baseof.html` file to ensure that certain scripts and tags are included only in the "preview" and "production" environments, instead of being excluded solely in the "development" environment.

### Changes to environment-specific logic:

* Updated the condition for including the Termly.io script to check if the environment is "preview" or "production" (`site/layouts/baseof.html`, line 8).
* Updated the condition for including the Google Tag Manager (noscript) tag to check if the environment is "preview" or "production" (`site/layouts/baseof.html`, line 32).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nkdAgility/NKDAgility.com/562)
<!-- Reviewable:end -->
