### PR TITLE
Update terms of business table to include training discount for each …

### DIFF
--- a/site/content/company/terms-of-business/index.md
+++ b/site/content/company/terms-of-business/index.md
@@ -166,17 +166,19 @@ This approach avoids complexity while ensuring you’re never surprised.
 Fees are all-inclusive for remote work.
 
 {{< table "table table-striped table-bordered" >}}
-| **Level** | **%** | **Weekly** | **Monthly** | **Quarterly** |
-| ------------------- | ----- | ------------- | ------------- | ------------- |
-| **Light** | 2.5% | £284 | £597 | £1,235 |
-| **Supportive** | 5% | £567 | £1,192 | £2,470 |
-| **Regular** | 25% | £6,800 | £14,300 | £29,500 |
-| **Deep** | 50% | £13,600 | £28,600 | £59,000 |
-| **Strategic** | 75% | _On request_ | _On request_ | _On request_ |
-| **Full-time** | 100% | _Not offered_ | _Not offered_ | _Not offered_ |
+
+| **Level**      | **%** | **Weekly**    | **Monthly**   | **Quarterly** | **Training Discount** |
+| -------------- | ----- | ------------- | ------------- | ------------- | --------------------- |
+| **Light**      | 2.5%  | £284          | £597          | £1,235        | 5%                    |
+| **Supportive** | 5%    | £567          | £1,192        | £2,470        | 5%                    |
+| **Regular**    | 25%   | £6,800        | £14,300       | £29,500       | 20%                   |
+| **Deep**       | 50%   | £13,600       | £28,600       | £59,000       | 40%                   |
+| **Strategic**  | 75%   | _On request_  | _On request_  | _On request_  | _On request_          |
+| **Full-time**  | 100%  | _Not offered_ | _Not offered_ | _Not offered_ | _Not offered_         |
+
 {{< /table >}}
 
-These fees do **not include training**, however, the **quarterly retainer** includes a 40% discount on training.
+These fees do **not include training**, however, the **quarterly retainer** includes a discount on training, noted above.
 
 ### Training Rates
 


### PR DESCRIPTION
This pull request updates the fee table in the `site/content/company/terms-of-business/index.md` file to provide clearer information about training discounts associated with each retainer level. The table now includes a new column for "Training Discount" and updates the explanatory text to match.

Fee structure and training discount updates:

* Added a "Training Discount" column to the retainer fee table, specifying the discount rate for each service level.
* Updated the explanatory text to reference the new discount column, making the training discount information clearer and more accurate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nkdAgility/NKDAgility.com/589)
<!-- Reviewable:end -->
