### PR TITLE
Enhance homepage cards section to limit displayed items and improve layout

### DIFF
--- a/site/layouts/_partials/cards-section.html
+++ b/site/layouts/_partials/cards-section.html
@@ -1,9 +1,15 @@
 {{- $sectionName := .SectionName }}
+{{- $maxItems := .MaxItems }}
 {{- $PagePermalink := .context.Page.Permalink }}
 {{- $section := .context.Site.GetPage "section" $sectionName }}
+{{- $pages := $section.Pages.ByWeight }}
+{{- $pageCount:= len $pages }}
+{{- if gt $maxItems 0 }}
+  {{- $pages = $pages | first $maxItems }}
+{{- end }}
 <div class="container">
   <div class="row">
-    {{- range $section.Pages.ByWeight }}
+    {{- range $pages }}
       {{- if not .Draft }}
         {{- if ne .Permalink $PagePermalink }}
           <div class="col-md-6 col-xl-6 d-flex">
@@ -14,4 +20,11 @@
       {{- end }}
     {{- end }}
   </div>
+  {{- if gt $pageCount $maxItems }}
+    <div class="row mt-5">
+      <div class="col-12 text-center">
+        <a href="{{ $section.Permalink }}" class="btn btn-outline-primary">Learn More About {{ $section.Title }}</a>
+      </div>
+    </div>
+  {{- end }}
 </div>

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -61,7 +61,7 @@
   <section class="container my-5">
     <h2>What you gain</h2>
     <p>You experience improved conditions across delivery, quality, and economic visibility. Teams deliver with greater predictability. Risk reduces. Innovation becomes sustainable.</p>
-    {{- partial "cards-section.html" (dict "context" . "SectionName" "outcomes") . }}
+    {{- partial "cards-section.html" (dict "context" . "SectionName" "outcomes" "MaxItems" 4) . }}
   </section>
   <section class="container my-5">
     <h2>How we work with you</h2>
@@ -84,7 +84,7 @@
   <section class="container my-5">
     <h2>What we provide</h2>
     <p>We deliver assessments, operating model design, coaching, and engineering excellence enablement. Our capabilities span strategy alignment, delivery system optimisation, and technical leadership development.</p>
-    {{- partial "cards-section.html" (dict "context" . "SectionName" "capabilities") }}
+    {{- partial "cards-section.html" (dict "context" . "SectionName" "capabilities" "MaxItems" 4) }}
   </section>
   <section class="container my-5">
     <h2>Experience and reach</h2>


### PR DESCRIPTION
This pull request updates the cards section logic to support limiting the number of displayed items and adds a "Learn More" button when there are additional items available. The changes improve user experience by making sections more concise and providing navigation to full lists when appropriate.

Enhancements to cards section display:

* Added a `MaxItems` parameter to the `cards-section.html` partial, allowing callers to specify the maximum number of items to display.
* Updated the logic in `cards-section.html` to only show up to `MaxItems` cards and to display a "Learn More" button linking to the full section if more items exist.

Integration into homepage sections:

* Modified the homepage (`index.html`) to use the new `MaxItems` parameter for the "outcomes" and "capabilities" sections, limiting each to four items. [[1]](diffhunk://#diff-21e2894b7c8e63e7903a92830fd641d6b7d5b298c1a5dbe834c0a5f24524a49fL64-R64) [[2]](diffhunk://#diff-21e2894b7c8e63e7903a92830fd641d6b7d5b298c1a5dbe834c0a5f24524a49fL87-R87)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nkdAgility/NKDAgility.com/667)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Limited the number of displayed items in outcomes and capabilities sections to a maximum of 4 items per section.
  * Added "Learn More About ..." buttons in sections with additional items, providing easy navigation to view the complete list of content in each section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->