### PR TITLE
Refine guidelines for case studies and client references in NKD markting positioning agent

### DIFF
--- a/.github/agents/nkda-marketing-positioning.agent.md
+++ b/.github/agents/nkda-marketing-positioning.agent.md
@@ -147,10 +147,12 @@ Do **not**:
 
 - use analogies
 - segment audiences explicitly (“for CIOs”, “for team leads”)
-- add case studies or client names
+- add client names
 - invent examples or data.
 
-Use British English.
+DO:
+
+- Use British English.
 
 ---
 
@@ -291,15 +293,19 @@ Use this as reference for:
 - engineering excellence framing
   Never copy content from blog posts directly, but use them to remain consistent in tone and assertions.
 
-### **3. Case Studies (General Patterns Only)**
+### **3. Case Studies**
 
 `site/content/resources/case-studies/*`
-Use case studies only as:
+Use case studies as:
 
 - validation of the types of problems NKD encounters
 - grounding for typical organisational conditions
-  Do **not** reference any case study explicitly.
-  Do **not** reproduce details, client names, or examples.
+- concrete proof points when strengthening a narrative
+- Reference case studies where appropriate using the path `/resources/case-studies`
+  When referencing case studies:
+- Link to them when they validate a specific claim or outcome
+- Do **not** reproduce details verbatim
+- Use them to ground abstract claims in real-world evidence
 
 ---
 


### PR DESCRIPTION
This pull request updates the `.github/agents/nkda-marketing-positioning.agent.md` guidelines to clarify how client names and case studies should be referenced. The main focus is on tightening restrictions around client identification and improving instructions for referencing case studies.

Guideline changes:

**Client and case study references**
* Updated the "Do not" section to prohibit adding client names, removing the previous mention of case studies and clarifying the restriction.
* Revised the case study usage instructions to allow referencing case studies by linking to their paths, but still restrict reproducing details verbatim and using client names. The guidelines now encourage linking case studies to validate claims or outcomes, rather than referencing them explicitly or copying details.

**General formatting**
* Moved the instruction to use British English from the "Do not" section to a new "DO" section for clarity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nkdAgility/NKDAgility.com/679)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated marketing positioning guidelines to enable structured use of case studies with explicit referencing and linking practices, enhancing evidence-based claim validation.
  * Improved formatting guidance and content rules organisation for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->